### PR TITLE
script name collision fix 

### DIFF
--- a/code-context/pyproject.toml
+++ b/code-context/pyproject.toml
@@ -24,8 +24,6 @@ dependencies = [
     "faiss-cpu>=1.12.0",
 ]
 
-[project.scripts]
-serve = "code_context:main"
 
 [build-system]
 requires = ["uv_build>=0.9.6,<0.10.0"]


### PR DESCRIPTION
quick fix because `uv run serve` from the repository root was running `code-context` instead of `openfilter-mcp` 