### PR TITLE
Fix/fastplaidectomy

### DIFF
--- a/code-context/pyproject.toml
+++ b/code-context/pyproject.toml
@@ -29,11 +29,8 @@ requires = ["uv_build>=0.9.6,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv]
-# Use pre-built wheels for llama-cpp-python based on platform:
-# - macOS (Darwin): Use Metal-accelerated wheels for Apple Silicon GPU support
-# - Linux: Use CUDA 12.4 wheels for NVIDIA GPU support
-# - CPU-only: Available via --index llama-cpp-python-cpu for Docker/CI builds
-# This avoids needing to compile from source and handles platform differences automatically
+config-settings-package = { "llama-cpp-python" = { "cmake.args" = "-DGGML_CUDA=on" } }
+
 
 [[tool.uv.index]]
 name = "llama-cpp-python-cuda"
@@ -52,8 +49,8 @@ explicit = true
 
 [tool.uv.sources]
 llama-cpp-python = [
+    { git = "https://github.com/abetlen/llama-cpp-python", marker = "sys_platform == 'linux'" },
     { index = "llama-cpp-python-metal", marker = "sys_platform == 'darwin'" },
-    { index = "llama-cpp-python-cuda", marker = "sys_platform == 'linux'" },
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,7 @@ index = "openfilter_mcp.preindex_repos:preindex_openfilter_repos"
 serve = "openfilter_mcp.server:main"
 
 [tool.uv]
-# Use pre-built wheels for llama-cpp-python based on platform:
-# - macOS (Darwin): Use Metal-accelerated wheels for Apple Silicon GPU support
-# - Linux: Use CUDA 12.4 wheels for NVIDIA GPU support
-# - CPU-only: Available via UV_INDEX_LLAMA_CPP_PYTHON_CPU=true for Docker/CI builds
-# This avoids needing to compile from source and handles platform differences automatically
+config-settings-package = { "llama-cpp-python" = { "cmake.args" = "-DGGML_CUDA=on" } }
 
 [[tool.uv.index]]
 name = "llama-cpp-python-cuda"
@@ -43,6 +39,6 @@ explicit = true
 [tool.uv.sources]
 code-context = { path = "./code-context" }
 llama-cpp-python = [
+    { git = "https://github.com/abetlen/llama-cpp-python", marker = "sys_platform == 'linux'" },
     { index = "llama-cpp-python-metal", marker = "sys_platform == 'darwin'" },
-    { index = "llama-cpp-python-cuda", marker = "sys_platform == 'linux'" },
 ]


### PR DESCRIPTION
CUDA 13 is not supported by llama-cpp-python wheels and fastplaid should not be in either pyproject.toml under the new indexing approach; this set of changes addresses both issues