### PR TITLE
fix(build): CUDA-accelerated llama-cpp-python for indexing and serve-time

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,76 @@
+name: Auto-tag on version bump
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Fetch tags
+        run: git fetch --tags origin
+
+      - name: Check if pyproject.toml changed
+        id: changed
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -q '^pyproject.toml$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read version from pyproject.toml
+        id: version
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          version=$(python3 << 'PYEOF'
+import sys, re, tomllib, pathlib
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+v = data['project']['version']
+if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', v):
+    print(f'::error::Version "{v}" does not match X.Y.Z', file=sys.stderr)
+    sys.exit(1)
+print(v)
+PYEOF
+          )
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        if: steps.changed.outputs.changed == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.changed.outputs.changed == 'true' && steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          if ! git push origin "$TAG" 2>&1; then
+            echo "::warning::Failed to push tag $TAG — may have been created by a concurrent run"
+          fi

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,24 +1,46 @@
-FROM python:3.12-slim
+# Stage 1: Build llama-cpp-python from source with CUDA support
+FROM nvidia/cuda:12.4.0-devel-ubuntu22.04 AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.9.6 /uv /uvx /bin/
 
 RUN apt-get update && apt-get install -y git curl gcc g++ && rm -rf /var/lib/apt/lists/*
+RUN uv python install 3.12
 
 WORKDIR /app
-
-# Copy lockfile + manifest first (cache deps layer when only source changes)
 COPY pyproject.toml README.md ./
 COPY code-context/ code-context/
 
-# Install deps first (cached unless pyproject.toml or uv.lock change)
-ENV CMAKE_ARGS="-DGGML_CUDA=off"
-RUN uv sync --no-dev --group code-search --no-install-workspace
+# Build from source with CUDA (uses root pyproject.toml git source + cmake args)
+RUN uv sync --python 3.12 --no-dev --group code-search --no-install-workspace
 
-# Now copy source + data (these layers invalidate on content changes)
+# Stage 2: Slim runtime with CUDA runtime libs only
+# Use debian:bookworm-slim + uv python install so the interpreter path matches
+# the builder stage — this lets us COPY the .venv without uv recreating it.
+FROM debian:bookworm-slim
+COPY --from=ghcr.io/astral-sh/uv:0.9.6 /uv /uvx /bin/
+
+RUN apt-get update && apt-get install -y git curl libgomp1 && rm -rf /var/lib/apt/lists/*
+RUN uv python install 3.12
+
+# Copy CUDA runtime libs from the builder (only what llama-cpp needs at runtime)
+COPY --from=builder /usr/local/cuda-12.4/targets/x86_64-linux/lib/libcudart.so* /usr/local/lib/
+COPY --from=builder /usr/local/cuda-12.4/targets/x86_64-linux/lib/libcublas.so* /usr/local/lib/
+COPY --from=builder /usr/local/cuda-12.4/targets/x86_64-linux/lib/libcublasLt.so* /usr/local/lib/
+RUN ldconfig
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY code-context/ code-context/
+
+# Copy the pre-built venv from stage 1 (includes CUDA-enabled llama-cpp-python)
+# Works because both stages use `uv python install 3.12` → same interpreter path.
+COPY --from=builder /app/.venv /app/.venv
+
+# Copy source + data
 COPY src/ src/
 COPY indexes/ indexes/
 COPY openfilter_repos_clones/ openfilter_repos_clones/
 
-# Install the workspace package itself
+# Install workspace package (uses existing venv, just links the project)
 RUN uv sync --no-dev --group code-search
 
 CMD ["uv", "run", "--no-sync", "serve"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -41,6 +41,6 @@ COPY indexes/ indexes/
 COPY openfilter_repos_clones/ openfilter_repos_clones/
 
 # Install workspace package (uses existing venv, just links the project)
-RUN uv sync --no-dev --group code-search
+RUN uv sync --python 3.12 --no-dev --group code-search
 
 CMD ["uv", "run", "--no-sync", "serve"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -40,7 +40,8 @@ COPY src/ src/
 COPY indexes/ indexes/
 COPY openfilter_repos_clones/ openfilter_repos_clones/
 
-# Install workspace package (uses existing venv, just links the project)
-RUN uv sync --python 3.12 --no-dev --group code-search --no-build-package llama-cpp-python
+# Install the workspace packages only — all deps (including CUDA-built
+# llama-cpp-python) are already in the copied venv from the builder stage.
+RUN uv pip install --python .venv/bin/python --no-deps -e . -e code-context/
 
 CMD ["uv", "run", "--no-sync", "serve"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -41,6 +41,6 @@ COPY indexes/ indexes/
 COPY openfilter_repos_clones/ openfilter_repos_clones/
 
 # Install workspace package (uses existing venv, just links the project)
-RUN uv sync --python 3.12 --no-dev --group code-search
+RUN uv sync --python 3.12 --no-dev --group code-search --no-build-package llama-cpp-python
 
 CMD ["uv", "run", "--no-sync", "serve"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -73,7 +73,7 @@ steps:
       - |
         SLIM_ONLY="${_SLIM_ONLY}"; if [[ "${TAG_NAME}" == *slim* ]]; then SLIM_ONLY=true; fi
         if [[ "$$SLIM_ONLY" == "true" ]]; then echo "SLIM_ONLY: skipping full build"; exit 0; fi
-        bash scripts/docker-build.sh --dockerfile Dockerfile.gpu --tag-suffix "" --latest-tag "latest"
+        bash scripts/docker-build.sh --dockerfile Dockerfile.gpu --tag-suffix "" --latest-tag "latest" --platform linux/amd64
 
   # Step 3: Slim Docker build (no code-context, no indexes, no ML deps)
   - name: 'gcr.io/cloud-builders/docker'

--- a/code-context/pyproject.toml
+++ b/code-context/pyproject.toml
@@ -53,7 +53,7 @@ explicit = true
 
 [tool.uv.sources]
 llama-cpp-python = [
-    { git = "https://github.com/abetlen/llama-cpp-python", marker = "sys_platform == 'linux'" },
+    { git = "https://github.com/abetlen/llama-cpp-python", tag = "v0.3.16", marker = "sys_platform == 'linux'" },
     { index = "llama-cpp-python-metal", marker = "sys_platform == 'darwin'" },
 ]
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,9 +53,11 @@ scripts/
 | Group | What it adds | When to use |
 |-------|-------------|-------------|
 | _(base)_ | Platform tools, tantivy, inflect | `uv sync` — slim installs |
-| `code-search` | code-context, torch, llama-cpp-python, faiss | `uv sync --group code-search` — full installs |
+| `code-search` | code-context, torch, llama-cpp-python, faiss | `uv sync --group code-search` — full installs (Linux requires CUDA toolkit; see note below) |
 | `dev` | pytest, httpx | `uv sync --group dev` — development |
 
+
+**Note on `code-search` group (Linux):** On Linux, `llama-cpp-python` is built from source with `-DGGML_CUDA=on`. This requires the CUDA toolkit (nvcc, CUDA headers/libs) to be installed on the host. If you develop on Linux without a CUDA-capable GPU, skip the `code-search` group or build inside the GPU Docker image instead.
 ## Releasing
 
 Releases are automated via [Google Cloud Build](../cloudbuild.yaml). Pushing a `v*` tag triggers a multi-arch (amd64 + arm64) build of both full and slim image variants. Builds are dry-run by default — the Terraform-managed trigger sets `_DRY_RUN=false` to enable pushing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,13 @@ name = "llama-cpp-python-cpu"
 url = "https://abetlen.github.io/llama-cpp-python/whl/cpu"
 explicit = true
 
+[tool.uv]
+config-settings-package = { "llama-cpp-python" = { "cmake.args" = "-DGGML_CUDA=on" } }
+
 [tool.uv.sources]
 code-context = { path = "./code-context" }
 llama-cpp-python = [
-    { index = "llama-cpp-python-cpu", marker = "sys_platform == 'linux'" },
+    { git = "https://github.com/abetlen/llama-cpp-python", marker = "sys_platform == 'linux'" },
     { index = "llama-cpp-python-metal", marker = "sys_platform == 'darwin'" },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ config-settings-package = { "llama-cpp-python" = { "cmake.args" = "-DGGML_CUDA=o
 [tool.uv.sources]
 code-context = { path = "./code-context" }
 llama-cpp-python = [
-    { git = "https://github.com/abetlen/llama-cpp-python", marker = "sys_platform == 'linux'" },
+    { git = "https://github.com/abetlen/llama-cpp-python", tag = "v0.3.16", marker = "sys_platform == 'linux'" },
     { index = "llama-cpp-python-metal", marker = "sys_platform == 'darwin'" },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openfilter-mcp"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "fastmcp>=2.13.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,6 @@ name = "llama-cpp-python-metal"
 url = "https://abetlen.github.io/llama-cpp-python/whl/metal"
 explicit = true
 
-[[tool.uv.index]]
-name = "llama-cpp-python-cpu"
-url = "https://abetlen.github.io/llama-cpp-python/whl/cpu"
-explicit = true
-
 [tool.uv]
 config-settings-package = { "llama-cpp-python" = { "cmake.args" = "-DGGML_CUDA=on" } }
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -17,12 +17,14 @@ TAG_NAME="${TAG_NAME:-}"
 DOCKERFILE=""
 TAG_SUFFIX=""
 LATEST_TAG=""
+PLATFORM="linux/amd64,linux/arm64"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dockerfile) DOCKERFILE="$2"; shift 2 ;;
     --tag-suffix) TAG_SUFFIX="$2"; shift 2 ;;
     --latest-tag) LATEST_TAG="$2"; shift 2 ;;
+    --platform) PLATFORM="$2"; shift 2 ;;
     *) echo "Unknown arg: $1" >&2; exit 1 ;;
   esac
 done
@@ -144,7 +146,7 @@ fi
 echo "Building with tags: ${TAGS}"
 # shellcheck disable=SC2086
 DOCKER_CONFIG=/builder/home/.docker docker buildx build \
-  --platform linux/amd64,linux/arm64 \
+  --platform "${PLATFORM}" \
   ${TAGS} \
   ${PUSH_FLAG} \
   -f "${DOCKERFILE}" .


### PR DESCRIPTION
- Build llama-cpp-python from git source with -DGGML_CUDA=on on Linux. Root pyproject.toml was overriding code-context's source config with the prebuilt CPU wheel index, silently disabling GPU offload even on machines/jobs with a CUDA-capable GPU.

- Rewrite Dockerfile.gpu as a proper multi-stage build:
  - Builder: nvidia/cuda:12.4.0-devel-ubuntu22.04 compiles llama-cpp from source with full CUDA toolkit
  - Runtime: debian:bookworm-slim + uv python install 3.12 (same interpreter path as builder so .venv COPY works without uv recreating it from scratch)
  - Copies libcudart, libcublas, libcublasLt from builder; libcuda.so.1 is injected at runtime by the nvidia container runtime (--gpus all)
  - Adds libgomp1 for OpenMP dependency

- Restrict Dockerfile.gpu to linux/amd64 in docker-build.sh (CUDA has no arm64 build path; multiplatform build was failing on arm64 trying to COPY x86_64 CUDA lib paths)