### PR TITLE
fix(ci): heredoc at column 0 broke YAML block scalar in auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -38,15 +38,14 @@ jobs:
         id: version
         if: steps.changed.outputs.changed == 'true'
         run: |
-          version=$(python3 << 'PYEOF'
-import sys, re, tomllib, pathlib
-data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
-v = data['project']['version']
-if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', v):
-    print(f'::error::Version "{v}" does not match X.Y.Z', file=sys.stderr)
-    sys.exit(1)
-print(v)
-PYEOF
+          version=$(python3 - << 'PYEOF'
+          import sys, re, tomllib, pathlib
+          v = tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version']
+          if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+', v):
+              print(f'::error::Version "{v}" does not match X.Y.Z', file=sys.stderr)
+              sys.exit(1)
+          print(v)
+          PYEOF
           )
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -103,21 +103,26 @@ else
     echo "Version tag build: ${TAG_NAME} (${DOCKERFILE})"
     NEW_VERSION=$(echo "${TAG_NAME}" | sed 's/^v//')
 
-    # Fetch current latest version from DockerHub
+    # Fetch current latest version from DockerHub (python3 instead of jq — not in cloud-builders/docker)
     LATEST_DIGEST=$(curl -s "https://hub.docker.com/v2/repositories/${_DOCKERHUB_REPO}/tags/${LATEST_TAG}" | \
-      jq -r '.images[0].digest // empty')
+      python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("images",[{}])[0].get("digest",""))' 2>/dev/null)
 
     CURRENT_VERSION=""
     if [[ -n "${LATEST_DIGEST}" ]]; then
-      # Build a jq filter that matches tags with or without the suffix
-      if [[ -n "${TAG_SUFFIX}" ]]; then
-        JQ_FILTER=".results[] | select(.images[].digest == \$digest) | .name | select(test(\"^v?[0-9]+\\\\.[0-9]+\\\\.[0-9]+${TAG_SUFFIX}$\")) | sub(\"${TAG_SUFFIX}$\"; \"\")"
-      else
-        JQ_FILTER='.results[] | select(.images[].digest == $digest) | .name | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))'
-      fi
       CURRENT_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/${_DOCKERHUB_REPO}/tags?page_size=100" | \
-        jq -r --arg digest "${LATEST_DIGEST}" "${JQ_FILTER}" | \
-        sed 's/^v//' | head -1)
+        python3 -c '
+import sys, json, re
+data = json.load(sys.stdin)
+digest = "'"${LATEST_DIGEST}"'"
+suffix = "'"${TAG_SUFFIX}"'"
+pat = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+" + re.escape(suffix) + r"$")
+for tag in data.get("results", []):
+    if any(img.get("digest") == digest for img in tag.get("images", [])):
+        name = tag["name"]
+        if pat.match(name):
+            print(re.sub(r"^v", "", name.removesuffix(suffix)))
+            break
+' | head -1)
     fi
     CURRENT_VERSION="${CURRENT_VERSION:-0.0.0}"
     echo "Current latest: ${CURRENT_VERSION}, New: ${NEW_VERSION}"


### PR DESCRIPTION
## Problem

The `openfilter-mcp-tag` Cloud Build flow has been broken since the CUDA build merge (`9a3ef0a`). Two independent bugs prevented production releases:

### Bug 1: `auto-tag.yml` YAML parse error

The Python heredoc body was at column 0 inside a YAML literal block scalar (`|`). YAML determines block content indentation from the first content line (10 spaces). Lines at column 0 terminate the block, so `import sys, re, tomllib, pathlib` was interpreted as a top-level YAML mapping key. GitHub Actions failed to parse the workflow file before any jobs started — all 4 runs since merge showed 0s duration and no jobs.

### Bug 2: `docker-build.sh` missing `jq`

The release path in `docker-build.sh` (hit only for `TAG_NAME=v*` without `-dev`) uses `jq` to query DockerHub for the current latest digest and resolve it to a semver tag. The `gcr.io/cloud-builders/docker` image does not have `jq`, causing exit code 127. Dev builds never hit this code path, so it went undetected.

## Fix

### `auto-tag.yml`
Changed from `python3 << 'PYEOF'` with body at column 0 to `python3 - << 'PYEOF'` with the heredoc body indented to YAML block level. YAML strips the uniform indent; the shell passes properly formatted Python to stdin.

### `docker-build.sh`
Replaced both `jq` invocations with equivalent `python3 -c` calls (`python3` is available in `gcr.io/cloud-builders/docker`).

## Verification

- YAML parses correctly (`yaml.safe_load` succeeds; GitHub Actions Test workflow ran on the PR branch without parse errors)
- Production build `4ca4f2b5` completed successfully with both fixes, pushing `plainsightai/openfilter-mcp:0.2.1` + `:latest` (full) and `:0.2.1-slim` + `:latest-slim` (slim) to DockerHub