### PR TITLE
feat(scopes): drive request_scoped_token from live /rbac/scopes (DT-134)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,10 +33,13 @@ Before making API calls, the agent requests a scoped token with permissions tail
 
 | Tool | Description |
 |------|-------------|
+| `list_grantable_scopes` | Enumerate the scopes the current caller can grant (sourced live from plainsight-api's `/rbac/scopes`) |
 | `request_scoped_token` | Request a scoped API token (absolute scopes, or delta via `add_scopes`/`remove_scopes`) |
 | `await_token_approval` | Block until browser-based approval completes (Claude Code flow) |
 | `get_token_status` | Check current scopes, expiry, and token state |
 | `clear_scoped_token` | Revoke the scoped token and revert to default credentials |
+
+Scope validation for `request_scoped_token` is driven by plainsight-api's `GET /rbac/scopes` — the same source the backend uses to enforce access. New sub-action scopes (e.g. `pipelineinstance:start`, `groundtruth:trigger`) added server-side are picked up immediately without an MCP release. If `/rbac/scopes` is unreachable, elicitation fails with a clear error rather than silently falling back to a stale list; retry after plainsight-api recovers.
 
 ### Choosing scope breadth
 
@@ -45,9 +48,9 @@ There is an inherent tension between **least privilege** (narrow scopes reduce b
 | Task profile | Recommended approach | Example scopes |
 |---|---|---|
 | Quick, focused query | Narrow — only the specific resources and actions needed | `filterpipeline:read,pipelineinstance:read` |
-| Broad investigation or long session | Wide read scopes so the agent can explore freely | `*:read` or a broad set of `<resource>:read` |
+| Broad investigation or long session | Wide read scopes so the agent can explore freely | Broad set of `<resource>:read` (there is no `*:read` shorthand in the live scope set) |
 | Task that clearly implies writes | Read + write for the relevant resources upfront | `filterpipeline:read,filterpipeline:update` |
-| Open-ended "fix everything" task | Wide reads, targeted writes — escalate via `add_scopes` only if new resource types arise | `*:read,filterpipeline:update` |
+| Open-ended "fix everything" task | Wide reads, targeted writes — escalate via `add_scopes` only if new resource types arise | Broad reads + `filterpipeline:update` |
 
 **Guidelines:**
 - Aim for the scope set that lets the agent complete the user's stated goal with **a single approval**.

--- a/src/openfilter_mcp/scopes.py
+++ b/src/openfilter_mcp/scopes.py
@@ -1,0 +1,102 @@
+"""Role-filtered RBAC scope introspection via plainsight-api GET /rbac/scopes.
+
+Used by request_scoped_token to validate elicitation against the authoritative
+scope set rather than a hand-rolled list that drifts from policies.csv.
+"""
+
+from __future__ import annotations
+
+import difflib
+from typing import Any
+
+import httpx
+from fastmcp.server.context import Context
+
+GRANTABLE_SCOPES_KEY = "rbac_grantable_scopes"
+
+
+class ScopesUnavailable(RuntimeError):
+    """Raised when GET /rbac/scopes fails. Elicitation refuses to proceed
+    rather than silently falling back to stale data (DT-134 acceptance)."""
+
+    def __init__(self, status: int | None, detail: str) -> None:
+        self.status = status
+        self.detail = detail
+        super().__init__(f"/rbac/scopes unavailable (status={status}): {detail}")
+
+
+async def fetch_grantable_scopes(client: httpx.AsyncClient) -> list[str]:
+    """GET /rbac/scopes; return the caller's grantable scope-value list.
+
+    Raises ScopesUnavailable on any non-2xx response, transport error, or
+    malformed body.
+    """
+    try:
+        resp = await client.get("/rbac/scopes")
+    except httpx.HTTPError as e:
+        raise ScopesUnavailable(None, f"transport error: {e}") from e
+
+    if resp.status_code // 100 != 2:
+        detail = resp.text[:500] if resp.text else "(empty body)"
+        raise ScopesUnavailable(resp.status_code, detail)
+
+    try:
+        body = resp.json()
+    except ValueError as e:
+        raise ScopesUnavailable(resp.status_code, f"non-JSON body: {e}") from e
+
+    scopes = body.get("scopes") if isinstance(body, dict) else None
+    if not isinstance(scopes, list):
+        raise ScopesUnavailable(resp.status_code, f"missing 'scopes' list in body: {body!r}")
+
+    values: list[str] = []
+    for entry in scopes:
+        if not isinstance(entry, dict) or not isinstance(entry.get("value"), str):
+            raise ScopesUnavailable(resp.status_code, f"malformed scope entry: {entry!r}")
+        values.append(entry["value"])
+    return values
+
+
+def is_scope_granted(requested: str, grantable: set[str]) -> bool:
+    """Does `grantable` cover `requested`?
+
+    - '*:*' in grantable covers any well-formed request.
+    - '<res>:*' in grantable covers '<res>:<any_action>'.
+    - Exact match always succeeds.
+    - A wildcard request ('*:*', '<res>:*') is only granted when that exact
+      wildcard (or a broader one) is in grantable — concrete tuples never
+      compose up to a wildcard.
+    """
+    if requested in grantable:
+        return True
+    parts = requested.split(":", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return False
+    res, act = parts
+    if "*:*" in grantable:
+        return True
+    if res == "*" or act == "*":
+        return False
+    return f"{res}:*" in grantable
+
+
+def suggest_grantable(requested: str, grantable: set[str]) -> str | None:
+    """Closest match for a rejected scope (difflib, cutoff 0.6). None if
+    nothing is close enough."""
+    if not grantable:
+        return None
+    matches = difflib.get_close_matches(requested, grantable, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+async def get_or_fetch_grantable(ctx: Context, client: httpx.AsyncClient) -> set[str]:
+    """Return the caller's grantable scopes, fetching once per MCP session.
+
+    Failures are not cached — subsequent calls retry the fetch.
+    """
+    cached: Any = await ctx.get_state(GRANTABLE_SCOPES_KEY)
+    if cached is not None:
+        return set(cached)
+    scopes = await fetch_grantable_scopes(client)
+    await ctx.set_state(GRANTABLE_SCOPES_KEY, scopes)
+    return set(scopes)

--- a/src/openfilter_mcp/scopes.py
+++ b/src/openfilter_mcp/scopes.py
@@ -121,6 +121,45 @@ def is_scope_granted(requested: str, grantable: set[str]) -> bool:
     return f"{res}:*" in grantable
 
 
+def classify_rejection(requested: str, grantable: set[str]) -> str:
+    """Explain *why* a rejected scope failed validation.
+
+    Disambiguates the four failure modes an agent typically hits — malformed
+    shape, unknown resource, unknown action under a known resource, or a
+    wildcard request that needs a wildcard grant — so the error message points
+    at the half that's actually wrong instead of one generic "not granted"
+    blob. Caller is responsible for first checking is_scope_granted; this
+    function assumes the request was already rejected.
+    """
+    parsed = parse_scope(requested)
+    if parsed is None:
+        return f"expected 'resource:action'; got {requested!r}"
+    res, act = parsed
+
+    # Decompose the grantable set once. parse_scope filters out any malformed
+    # entries defensively (fetch_grantable_scopes already validates shape, but
+    # this keeps the classifier honest if it's ever called with an ad-hoc set).
+    pairs = [p for p in (parse_scope(g) for g in grantable) if p is not None]
+    granted_resources = {r for r, _ in pairs}
+
+    # Wildcard requests fail for a different reason than concrete typos: the
+    # user is asking to escalate to a wildcard grant they don't hold. Surface
+    # that directly rather than reporting "unknown action '*'".
+    if res == "*" and act == "*":
+        return "admin scope; requires '*:*' in your grantable set"
+    if act == "*":
+        return f"wildcard action; requires {res!r}:* or '*:*' in your grantable set"
+    if res == "*":
+        return "cross-resource wildcard; requires '*:*' in your grantable set"
+
+    if res not in granted_resources:
+        known = sorted(granted_resources)
+        return f"unknown resource {res!r} (known resources: {known})"
+
+    actions = sorted({a for r, a in pairs if r == res})
+    return f"unknown action {act!r} for resource {res!r} (granted actions: {actions})"
+
+
 def suggest_grantable(requested: str, grantable: set[str]) -> str | None:
     """Closest match for a rejected scope (difflib, cutoff 0.6). None if
     nothing is close enough."""
@@ -134,13 +173,13 @@ def suggest_grantable(requested: str, grantable: set[str]) -> str | None:
 
 
 async def get_or_fetch_grantable(ctx: Context, client: httpx.AsyncClient) -> set[str]:
-    """Return the caller's grantable scopes, fetching once per MCP request.
+    """Return the caller's grantable scopes, fetching once per MCP session.
 
-    Failures are not cached — subsequent calls retry the fetch.
+    Successes are stored via ctx.set_state with the default serializable=True,
+    which routes them through fastmcp's pydantic-backed session store — so the
+    cache lives for the session, not just the current request. Failures are
+    not cached; subsequent calls retry the fetch.
     """
-    # `client` is the shared server-identity httpx client, so the grantable
-    # set it returns is effectively process-global even though this cache is
-    # keyed per-request via ctx.get_state/set_state.
     cached: Any = await ctx.get_state(GRANTABLE_SCOPES_KEY)
     if cached is not None:
         return set(cached)

--- a/src/openfilter_mcp/scopes.py
+++ b/src/openfilter_mcp/scopes.py
@@ -59,11 +59,21 @@ async def fetch_grantable_scopes(client: httpx.AsyncClient) -> list[str]:
     # failures (missing 'scopes' key, HTTP error, non-JSON body) still raise
     # ScopesUnavailable above.
     values: list[str] = []
-    for entry in scopes:
+    skipped = 0
+    for idx, entry in enumerate(scopes):
         if not isinstance(entry, dict) or not isinstance(entry.get("value"), str):
-            logger.warning("Skipping malformed /rbac/scopes entry: %r", entry)
+            logger.warning(
+                "Skipping malformed /rbac/scopes entry at index %d: %r", idx, entry
+            )
+            skipped += 1
             continue
         values.append(entry["value"])
+    if skipped:
+        logger.warning(
+            "/rbac/scopes: %d of %d entries skipped due to malformed shape",
+            skipped,
+            len(scopes),
+        )
     return values
 
 
@@ -106,25 +116,29 @@ def suggest_grantable(requested: str, grantable: set[str]) -> str | None:
 
 
 async def get_or_fetch_grantable(ctx: Context, client: httpx.AsyncClient) -> set[str]:
-    """Return the caller's grantable scopes, fetching once per MCP session.
+    """Return the caller's grantable scopes, fetching once per MCP request.
 
     Failures are not cached — subsequent calls retry the fetch.
     """
     # `client` is the shared server-identity httpx client, so the grantable
     # set it returns is effectively process-global even though this cache is
-    # keyed per-session via ctx.get_state/set_state.
+    # keyed per-request via ctx.get_state/set_state.
     cached: Any = await ctx.get_state(GRANTABLE_SCOPES_KEY)
     if cached is not None:
         return set(cached)
 
-    # Serialize concurrent first-fetches within a session (e.g.
+    # Serialize concurrent first-fetches within a request (e.g.
     # list_grantable_scopes and request_scoped_token racing on a cold cache)
-    # so at most one GET /rbac/scopes is in flight per session. Double-check
+    # so at most one GET /rbac/scopes is in flight per request. Double-check
     # the cache after acquiring the lock so losers of the race don't refetch.
+    # The lock is stored with serializable=False because asyncio.Lock cannot
+    # be round-tripped through fastmcp's pydantic-backed session store; this
+    # routes it into the request-scoped dict instead, which is the correct
+    # scope for intra-request dedup anyway.
     lock: Any = await ctx.get_state(GRANTABLE_SCOPES_LOCK_KEY)
     if lock is None:
         lock = asyncio.Lock()
-        await ctx.set_state(GRANTABLE_SCOPES_LOCK_KEY, lock)
+        await ctx.set_state(GRANTABLE_SCOPES_LOCK_KEY, lock, serializable=False)
 
     async with lock:
         cached = await ctx.get_state(GRANTABLE_SCOPES_KEY)

--- a/src/openfilter_mcp/scopes.py
+++ b/src/openfilter_mcp/scopes.py
@@ -38,7 +38,12 @@ async def fetch_grantable_scopes(client: httpx.AsyncClient) -> list[str]:
     """
     try:
         resp = await client.get("/rbac/scopes")
-    except httpx.HTTPError as e:
+    except httpx.RequestError as e:
+        # Only narrow this to transport-level errors. The authenticated client
+        # doesn't configure raise_for_status, so httpx.HTTPStatusError won't
+        # fire here today — but if someone wires up a response hook later, we
+        # want a real HTTP status error to propagate rather than be swallowed
+        # as a "transport error" with status=None.
         raise ScopesUnavailable(None, f"transport error: {e}") from e
 
     if resp.status_code // 100 != 2:
@@ -111,7 +116,10 @@ def suggest_grantable(requested: str, grantable: set[str]) -> str | None:
     nothing is close enough."""
     if not grantable:
         return None
-    matches = difflib.get_close_matches(requested, grantable, n=1, cutoff=0.6)
+    # sorted() for deterministic suggestions: set iteration order is
+    # hash-randomized, so when two candidates are equidistant, difflib would
+    # otherwise pick different winners across runs.
+    matches = difflib.get_close_matches(requested, sorted(grantable), n=1, cutoff=0.6)
     return matches[0] if matches else None
 
 

--- a/src/openfilter_mcp/scopes.py
+++ b/src/openfilter_mcp/scopes.py
@@ -6,13 +6,18 @@ scope set rather than a hand-rolled list that drifts from policies.csv.
 
 from __future__ import annotations
 
+import asyncio
 import difflib
+import logging
 from typing import Any
 
 import httpx
 from fastmcp.server.context import Context
 
+logger = logging.getLogger(__name__)
+
 GRANTABLE_SCOPES_KEY = "rbac_grantable_scopes"
+GRANTABLE_SCOPES_LOCK_KEY = "rbac_grantable_scopes_lock"
 
 
 class ScopesUnavailable(RuntimeError):
@@ -49,10 +54,15 @@ async def fetch_grantable_scopes(client: httpx.AsyncClient) -> list[str]:
     if not isinstance(scopes, list):
         raise ScopesUnavailable(resp.status_code, f"missing 'scopes' list in body: {body!r}")
 
+    # Per-entry malformation is log-and-skip rather than fatal: a single bad
+    # row upstream shouldn't disable scope validation wholesale. Structural
+    # failures (missing 'scopes' key, HTTP error, non-JSON body) still raise
+    # ScopesUnavailable above.
     values: list[str] = []
     for entry in scopes:
         if not isinstance(entry, dict) or not isinstance(entry.get("value"), str):
-            raise ScopesUnavailable(resp.status_code, f"malformed scope entry: {entry!r}")
+            logger.warning("Skipping malformed /rbac/scopes entry: %r", entry)
+            continue
         values.append(entry["value"])
     return values
 
@@ -66,13 +76,19 @@ def is_scope_granted(requested: str, grantable: set[str]) -> bool:
     - A wildcard request ('*:*', '<res>:*') is only granted when that exact
       wildcard (or a broader one) is in grantable — concrete tuples never
       compose up to a wildcard.
+    - Malformed requests (missing ':', empty half, extra ':' in the action
+      half, e.g. 'filterpipeline:read:extra') are rejected regardless of
+      what's in `grantable` — a wildcard grant does not paper over a bad
+      shape.
     """
+    # Shape validation must run before the exact-match and wildcard fast
+    # paths; otherwise a malformed requested scope like 'a:b:c' could be
+    # covered by 'a:*' or '*:*'.
+    res, sep, act = requested.partition(":")
+    if sep != ":" or not res or not act or ":" in act:
+        return False
     if requested in grantable:
         return True
-    parts = requested.split(":", 1)
-    if len(parts) != 2 or not parts[0] or not parts[1]:
-        return False
-    res, act = parts
     if "*:*" in grantable:
         return True
     if res == "*" or act == "*":
@@ -94,9 +110,26 @@ async def get_or_fetch_grantable(ctx: Context, client: httpx.AsyncClient) -> set
 
     Failures are not cached — subsequent calls retry the fetch.
     """
+    # `client` is the shared server-identity httpx client, so the grantable
+    # set it returns is effectively process-global even though this cache is
+    # keyed per-session via ctx.get_state/set_state.
     cached: Any = await ctx.get_state(GRANTABLE_SCOPES_KEY)
     if cached is not None:
         return set(cached)
-    scopes = await fetch_grantable_scopes(client)
-    await ctx.set_state(GRANTABLE_SCOPES_KEY, scopes)
-    return set(scopes)
+
+    # Serialize concurrent first-fetches within a session (e.g.
+    # list_grantable_scopes and request_scoped_token racing on a cold cache)
+    # so at most one GET /rbac/scopes is in flight per session. Double-check
+    # the cache after acquiring the lock so losers of the race don't refetch.
+    lock: Any = await ctx.get_state(GRANTABLE_SCOPES_LOCK_KEY)
+    if lock is None:
+        lock = asyncio.Lock()
+        await ctx.set_state(GRANTABLE_SCOPES_LOCK_KEY, lock)
+
+    async with lock:
+        cached = await ctx.get_state(GRANTABLE_SCOPES_KEY)
+        if cached is not None:
+            return set(cached)
+        scopes = await fetch_grantable_scopes(client)
+        await ctx.set_state(GRANTABLE_SCOPES_KEY, scopes)
+        return set(scopes)

--- a/src/openfilter_mcp/scopes.py
+++ b/src/openfilter_mcp/scopes.py
@@ -82,6 +82,20 @@ async def fetch_grantable_scopes(client: httpx.AsyncClient) -> list[str]:
     return values
 
 
+def parse_scope(s: str) -> tuple[str, str] | None:
+    """Split a scope into (resource, action), or None if malformed.
+
+    Shape rule: exactly one ':' separating non-empty halves; stray colons
+    in the action half (e.g. 'a:b:c') are malformed. Single source of truth
+    for scope shape — a wildcard grant must not paper over a bad shape, so
+    this check runs before any wildcard/exact-match logic in callers.
+    """
+    res, sep, act = s.partition(":")
+    if sep != ":" or not res or not act or ":" in act:
+        return None
+    return res, act
+
+
 def is_scope_granted(requested: str, grantable: set[str]) -> bool:
     """Does `grantable` cover `requested`?
 
@@ -91,17 +105,13 @@ def is_scope_granted(requested: str, grantable: set[str]) -> bool:
     - A wildcard request ('*:*', '<res>:*') is only granted when that exact
       wildcard (or a broader one) is in grantable — concrete tuples never
       compose up to a wildcard.
-    - Malformed requests (missing ':', empty half, extra ':' in the action
-      half, e.g. 'filterpipeline:read:extra') are rejected regardless of
-      what's in `grantable` — a wildcard grant does not paper over a bad
-      shape.
+    - Malformed requests are rejected regardless of what's in `grantable`;
+      see `parse_scope` for the shape rule.
     """
-    # Shape validation must run before the exact-match and wildcard fast
-    # paths; otherwise a malformed requested scope like 'a:b:c' could be
-    # covered by 'a:*' or '*:*'.
-    res, sep, act = requested.partition(":")
-    if sep != ":" or not res or not act or ":" in act:
+    parsed = parse_scope(requested)
+    if parsed is None:
         return False
+    res, act = parsed
     if requested in grantable:
         return True
     if "*:*" in grantable:

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -53,6 +53,7 @@ from openfilter_mcp.scopes import (
     ScopesUnavailable,
     get_or_fetch_grantable,
     is_scope_granted,
+    parse_scope,
     suggest_grantable,
 )
 
@@ -780,12 +781,9 @@ def create_mcp_server() -> FastMCP:
 
             errors = []
             for s in scope_list:
-                # Shape check: exactly one ':' separating non-empty resource
-                # and non-empty action. Extra colons (e.g. 'a:b:c') are
-                # rejected — is_scope_granted applies the same rule, but we
-                # surface a clearer 'expected resource:action' error here.
-                res, sep, act = s.partition(":")
-                if sep != ":" or not res or not act or ":" in act:
+                # Pre-check shape so a malformed scope gets a clearer error
+                # than the generic 'not in your grantable scope set'.
+                if parse_scope(s) is None:
                     errors.append(f"{s} (expected 'resource:action')")
                     continue
                 if not is_scope_granted(s, grantable):

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -49,6 +49,12 @@ from openfilter_mcp.entity_tools import register_entity_tools, SESSION_TOKEN_KEY
 from openfilter_mcp.approval_server import register_approval_routes
 from openfilter_mcp.redact import register_sensitive
 from openfilter_mcp.preindex_repos import MONOREPO_CLONE_DIR
+from openfilter_mcp.scopes import (
+    ScopesUnavailable,
+    get_or_fetch_grantable,
+    is_scope_granted,
+    suggest_grantable,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -324,7 +330,7 @@ OpenFilter MCP provides entity CRUD tools for the Plainsight API and semantic co
 **Token scoping (important):** Before making ANY API calls, you should request a scoped token with the minimum permissions your task requires. This follows the principle of least privilege and protects against accidental modifications to resources outside the task scope — even for read-only operations.
 
 How to scope a session:
-1. Determine which entity types and actions your task needs (use `list_entity_types` to discover available resources).
+1. Determine which entity types and actions your task needs (use `list_entity_types` to discover available resources; use `list_grantable_scopes` to enumerate the exact scope strings your role can grant, including sub-actions like `start`/`stop`/`trigger`).
 2. Call `request_scoped_token` with a comma-separated list of "resource:action" scopes.
    - The user will be asked to approve via an interactive dialog or browser page.
    - If the response includes an `approval_url`, tell the user to open it in their browser,
@@ -333,7 +339,7 @@ How to scope a session:
 4. Use `get_token_status` to check current permissions and expiry.
 5. Use `clear_scoped_token` to revert to the default token.
 
-Scope format: "resource:action" where resource is any entity type (or * for all resources) and action is read, create, update, delete, or * for all actions. Examples: "project:read,filterpipeline:read", "filterpipeline:*,pipelineinstance:*", "*:read" (read all resources), "*:*" (full access).
+Scope format: "resource:action" where resource is any entity type (or * for all resources) and action is drawn from the live policies — read, create, update, delete, plus per-domain sub-actions like start/stop/trigger/upload where applicable. Validation is driven by `/rbac/scopes`, so call `list_grantable_scopes` to see the authoritative set for your role. Examples: "project:read,filterpipeline:read", "filterpipeline:*,pipelineinstance:*", "pipelineinstance:start,pipelineinstance:stop", "*:*" (admin only).
 
 IMPORTANT: Resource names and entity_type values are lowercase with NO underscores or hyphens. Use 'filterpipeline' (not 'filter_pipeline'), 'pipelineinstance' (not 'pipeline_instance'), 'sourceconfig' (not 'source_config'). Use list_entity_types() to discover valid names.
 
@@ -346,10 +352,10 @@ Choosing the right scope breadth — security vs. autonomy:
 Narrower scopes protect against accidental modifications, but overly narrow scopes cause repeated approval prompts that slow the user down and create approval fatigue. The right scope set depends on the task:
 
 - **Quick, focused task** (e.g., "check if pipeline X is running"): request only the specific scopes needed — `filterpipeline:read,pipelineinstance:read`.
-- **Broad investigation or long-running session** (e.g., "audit everything in my project"): request wider read scopes upfront — `*:read` or a broad set of resource types — so you can explore freely without re-prompting.
+- **Broad investigation or long-running session** (e.g., "audit everything in my project"): request wider read scopes upfront — a broad set of per-resource reads like `project:read,filterpipeline:read,pipelineinstance:read,...` — so you can explore freely without re-prompting. (There is no `*:read` shorthand; `/rbac/scopes` only emits per-resource wildcards like `filterpipeline:*` or the admin-only `*:*`.)
 - **Tasks likely to involve writes**: if the user's intent clearly implies modifications (e.g., "fix the misconfigured pipeline"), request both read AND write scopes for the relevant resources upfront rather than forcing a separate escalation.
 
-As a guideline: prefer the scope set that lets you complete the user's stated goal with a single approval. Avoid wildcard write scopes (`*:*`, `*:update`) unless the task genuinely requires broad write access. When in doubt, lean toward slightly broader read scopes and narrower write scopes — reads are low-risk, writes deserve more scrutiny.
+As a guideline: prefer the scope set that lets you complete the user's stated goal with a single approval. Avoid broad wildcard grants like `*:*` or per-resource writes (`filterpipeline:*`) when concrete actions would do. When in doubt, lean toward slightly broader read scopes and narrower write scopes — reads are low-risk, writes deserve more scrutiny.
 
 Tool usage tips:
 - list_entities uses `filters` (not `query_params`) for HTTP query parameters. Example: list_entities('filterpipeline', filters={'project': '<id>'}).
@@ -648,6 +654,30 @@ def create_mcp_server() -> FastMCP:
     if has_auth and client:
 
         @mcp.tool()
+        async def list_grantable_scopes(ctx: Context | None = None) -> Dict[str, Any]:
+            """List the RBAC scopes the current caller can grant when creating
+            an API token via request_scoped_token.
+
+            The list is fetched from plainsight-api's GET /rbac/scopes (role-
+            filtered to your Casbin role) and cached for this MCP session.
+            Call this before request_scoped_token if you're unsure which scope
+            strings are valid for your role — avoids trial-and-error validation
+            errors and picks up new sub-action scopes (e.g., 'start', 'trigger')
+            without an MCP release.
+
+            Returns:
+                {"scopes": ["filterpipeline:read", "filterpipeline:*", ...]}
+                sorted. Or {"error": ...} if /rbac/scopes is unreachable.
+            """
+            if not ctx:
+                return {"error": "This tool requires a session context. Ensure your MCP client provides one."}
+            try:
+                grantable = await get_or_fetch_grantable(ctx, client)
+            except ScopesUnavailable as e:
+                return {"error": f"/rbac/scopes unavailable (status={e.status}): {e.detail}"}
+            return {"scopes": sorted(grantable)}
+
+        @mcp.tool()
         async def request_scoped_token(
             scopes: str | None = None,
             add_scopes: str | None = None,
@@ -688,16 +718,18 @@ def create_mcp_server() -> FastMCP:
 
             Args:
                 scopes: Comma-separated list of permission scopes to request
-                    (replaces all current scopes). Format: "resource:action"
-                    where resource is any entity type or * for all resources,
-                    and action is read, create, update, delete, or *.
+                    (replaces all current scopes). Format: "resource:action",
+                    validated against the caller's grantable set from
+                    plainsight-api's /rbac/scopes (so sub-action scopes like
+                    'start', 'stop', 'trigger', 'upload' are accepted if your
+                    role covers them). Call list_grantable_scopes() to
+                    enumerate exactly what you can request — beats guessing.
                     IMPORTANT: Resource names are lowercase with NO underscores
                     or hyphens — e.g., 'filterpipeline' not 'filter_pipeline',
-                    'pipelineinstance' not 'pipeline_instance'. Use
-                    list_entity_types() to discover valid resource names.
+                    'pipelineinstance' not 'pipeline_instance'.
                     Examples: "project:read,filterpipeline:read,pipelineinstance:read",
                              "filterpipeline:*,pipelineinstance:*",
-                             "*:read" (read all resources), "*:*" (full access)
+                             "*:*" (full access; admin roles only).
                 add_scopes: Comma-separated scopes to ADD to the current token.
                     Example: "filterpipeline:update" to add write access while
                     keeping existing read scopes.
@@ -736,24 +768,27 @@ def create_mcp_server() -> FastMCP:
             else:
                 return {"error": "Provide either 'scopes' (absolute) or 'add_scopes'/'remove_scopes' (delta)."}
 
-            valid_actions = {"read", "create", "update", "delete", "*"}
-            valid_resources = set(registry.list_entities()) if registry else set()
+            try:
+                grantable = await get_or_fetch_grantable(ctx, client)
+            except ScopesUnavailable as e:
+                return {"error": (
+                    f"Cannot validate requested scopes: /rbac/scopes is unavailable "
+                    f"(status={e.status}): {e.detail}. Refusing to approve token "
+                    f"creation against an unverified scope set. Retry after "
+                    f"plainsight-api recovers."
+                )}
+
             errors = []
             for s in scope_list:
-                parts = s.split(":", 1)
-                if len(parts) != 2:
+                if ":" not in s or not all(s.split(":", 1)):
                     errors.append(f"{s} (expected 'resource:action')")
                     continue
-                resource, action = parts
-                if action not in valid_actions:
-                    errors.append(f"{s} (unknown action '{action}', expected: {', '.join(sorted(valid_actions))})")
-                elif resource != "*" and valid_resources and resource not in valid_resources:
-                    suggestions = registry.suggest_entity(resource, limit=3) if registry else []
-                    if suggestions:
-                        hint = f"did you mean: {', '.join(suggestions)}?"
-                        errors.append(f"{s} (unknown resource '{resource}', {hint})")
+                if not is_scope_granted(s, grantable):
+                    hint = suggest_grantable(s, grantable)
+                    if hint:
+                        errors.append(f"{s} (not in your grantable scope set; did you mean '{hint}'?)")
                     else:
-                        errors.append(f"{s} (unknown resource '{resource}', available: {', '.join(sorted(valid_resources))})")
+                        errors.append(f"{s} (not in your grantable scope set)")
             if errors:
                 return {"error": f"Invalid scopes: {errors}"}
 

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -780,7 +780,12 @@ def create_mcp_server() -> FastMCP:
 
             errors = []
             for s in scope_list:
-                if ":" not in s or not all(s.split(":", 1)):
+                # Shape check: exactly one ':' separating non-empty resource
+                # and non-empty action. Extra colons (e.g. 'a:b:c') are
+                # rejected — is_scope_granted applies the same rule, but we
+                # surface a clearer 'expected resource:action' error here.
+                res, sep, act = s.partition(":")
+                if sep != ":" or not res or not act or ":" in act:
                     errors.append(f"{s} (expected 'resource:action')")
                     continue
                 if not is_scope_granted(s, grantable):

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -51,9 +51,9 @@ from openfilter_mcp.redact import register_sensitive
 from openfilter_mcp.preindex_repos import MONOREPO_CLONE_DIR
 from openfilter_mcp.scopes import (
     ScopesUnavailable,
+    classify_rejection,
     get_or_fetch_grantable,
     is_scope_granted,
-    parse_scope,
     suggest_grantable,
 )
 
@@ -781,17 +781,17 @@ def create_mcp_server() -> FastMCP:
 
             errors = []
             for s in scope_list:
-                # Pre-check shape so a malformed scope gets a clearer error
-                # than the generic 'not in your grantable scope set'.
-                if parse_scope(s) is None:
-                    errors.append(f"{s} (expected 'resource:action')")
+                if is_scope_granted(s, grantable):
                     continue
-                if not is_scope_granted(s, grantable):
-                    hint = suggest_grantable(s, grantable)
-                    if hint:
-                        errors.append(f"{s} (not in your grantable scope set; did you mean '{hint}'?)")
-                    else:
-                        errors.append(f"{s} (not in your grantable scope set)")
+                # classify_rejection splits "unknown resource X" from "unknown
+                # action Y for resource Z" so agents can fix the wrong half
+                # directly instead of guessing from a generic rejection.
+                reason = classify_rejection(s, grantable)
+                hint = suggest_grantable(s, grantable)
+                if hint:
+                    errors.append(f"{s} ({reason}; did you mean '{hint}'?)")
+                else:
+                    errors.append(f"{s} ({reason})")
             if errors:
                 return {"error": f"Invalid scopes: {errors}"}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,14 @@ def stub_grantable_scopes_in_server():
 
     Patches the binding inside openfilter_mcp.server only — tests in
     test_scopes.py import from openfilter_mcp.scopes and are unaffected.
+
+    Fails loudly if the target symbol is missing: if `get_or_fetch_grantable`
+    is renamed or moved, we'd rather the fixture error than silently no-op
+    and let every dependent test either hit the real /rbac/scopes endpoint
+    or fail cryptically elsewhere.
     """
-    try:
-        with patch(
-            "openfilter_mcp.server.get_or_fetch_grantable",
-            new=AsyncMock(return_value={"*:*"}),
-        ):
-            yield
-    except (ImportError, AttributeError):
+    with patch(
+        "openfilter_mcp.server.get_or_fetch_grantable",
+        new=AsyncMock(return_value={"*:*"}),
+    ):
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared test configuration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -14,4 +14,22 @@ def allow_unscoped_token_in_tests():
     this by patching ALLOW_UNSCOPED_TOKEN themselves.
     """
     with patch("openfilter_mcp.entity_tools.ALLOW_UNSCOPED_TOKEN", True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def stub_grantable_scopes_in_server():
+    """Short-circuit request_scoped_token's live /rbac/scopes fetch for tests
+    that don't specifically exercise it.
+
+    Patches the binding inside openfilter_mcp.server only — tests in
+    test_scopes.py import from openfilter_mcp.scopes and are unaffected.
+    """
+    try:
+        with patch(
+            "openfilter_mcp.server.get_or_fetch_grantable",
+            new=AsyncMock(return_value={"*:*"}),
+        ):
+            yield
+    except (ImportError, AttributeError):
         yield

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,5 +1,6 @@
 """Unit tests for openfilter_mcp.scopes."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -58,6 +59,16 @@ class TestIsScopeGranted:
         assert not is_scope_granted(":action", {"*:*"})
         assert not is_scope_granted("resource:", {"*:*"})
         assert not is_scope_granted("", {"*:*"})
+
+    def test_extra_colon_in_action_rejected_by_wildcards(self):
+        # A stray-colon scope is malformed and must be rejected regardless
+        # of how broad the grant is — neither a resource-wildcard nor the
+        # admin wildcard should paper over a bad shape.
+        assert not is_scope_granted("filterpipeline:read:extra", {"filterpipeline:*"})
+        assert not is_scope_granted("filterpipeline:read:extra", {"*:*"})
+        assert not is_scope_granted("filterpipeline:read:extra", {"filterpipeline:read:extra"})
+        # Multiple extra colons: still malformed.
+        assert not is_scope_granted("a:b:c:d", {"*:*"})
 
     def test_sub_action_scopes(self):
         # The drift bug this ticket fixes: sub-actions like 'start', 'trigger',
@@ -156,14 +167,39 @@ class TestFetchGrantableScopes:
             with pytest.raises(ScopesUnavailable):
                 await fetch_grantable_scopes(client)
 
-    async def test_malformed_scope_entry_raises(self, httpx_mock):
+    async def test_malformed_scope_entry_skipped_with_warning(self, httpx_mock, caplog):
+        # Per-entry malformation is log-and-skip, not fatal — a single bad
+        # row upstream shouldn't disable scope validation wholesale. Only
+        # structural failures (missing top-level 'scopes' key, HTTP error,
+        # non-JSON body) should raise ScopesUnavailable.
         httpx_mock.add_response(
             url=f"{_BASE_URL}/rbac/scopes",
-            json={"scopes": [{"domain": "project", "action": "read"}]},  # no 'value'
+            json={
+                "scopes": [
+                    {"value": "project:read", "domain": "project", "action": "read"},
+                    {"domain": "broken", "action": "read"},  # missing 'value'
+                ],
+            },
         )
-        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
-            with pytest.raises(ScopesUnavailable):
-                await fetch_grantable_scopes(client)
+        with caplog.at_level("WARNING", logger="openfilter_mcp.scopes"):
+            async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+                result = await fetch_grantable_scopes(client)
+        assert result == ["project:read"]
+        assert any("malformed" in rec.message.lower() for rec in caplog.records), (
+            f"expected a 'malformed' warning, got {[r.message for r in caplog.records]}"
+        )
+
+    async def test_all_entries_malformed_yields_empty_list(self, httpx_mock, caplog):
+        # Edge case: every entry is bad. We still don't raise — the
+        # structural contract (top-level 'scopes' list) was satisfied.
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            json={"scopes": [{"domain": "x"}, "not-a-dict", {"value": 42}]},
+        )
+        with caplog.at_level("WARNING", logger="openfilter_mcp.scopes"):
+            async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+                result = await fetch_grantable_scopes(client)
+        assert result == []
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +220,10 @@ class TestGetOrFetchGrantable:
         async with httpx.AsyncClient(base_url=_BASE_URL) as client:
             result = await get_or_fetch_grantable(ctx, client)
         assert result == {"project:read"}
-        ctx.set_state.assert_awaited_once_with(GRANTABLE_SCOPES_KEY, ["project:read"])
+        # The scopes list must be written back to the session cache. (The
+        # per-session lock is also written on cold sessions, so we check
+        # for this specific call rather than asserting a single write.)
+        ctx.set_state.assert_any_await(GRANTABLE_SCOPES_KEY, ["project:read"])
 
     async def test_uses_cache_skips_fetch(self, httpx_mock):
         ctx = MagicMock()
@@ -204,4 +243,46 @@ class TestGetOrFetchGrantable:
         async with httpx.AsyncClient(base_url=_BASE_URL) as client:
             with pytest.raises(ScopesUnavailable):
                 await get_or_fetch_grantable(ctx, client)
-        ctx.set_state.assert_not_called()
+        # The lock may be persisted on a cold session, but the scopes list
+        # itself must never be written on failure — otherwise a transient
+        # error would poison the cache for the rest of the session.
+        scope_writes = [
+            c for c in ctx.set_state.await_args_list
+            if c.args and c.args[0] == GRANTABLE_SCOPES_KEY
+        ]
+        assert scope_writes == []
+
+    async def test_concurrent_first_fetch_is_deduped(self, httpx_mock):
+        """Two concurrent cold-cache callers must share a single
+        GET /rbac/scopes via the session-scoped lock + double-check."""
+        # Shared per-session state: get_state/set_state read/write this dict
+        # so both coroutines see each other's writes like the real ctx would.
+        state: dict[str, object] = {}
+
+        async def get_state(key):
+            return state.get(key)
+
+        async def set_state(key, value):
+            state[key] = value
+
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(side_effect=get_state)
+        ctx.set_state = AsyncMock(side_effect=set_state)
+
+        # Register the endpoint once; pytest-httpx will replay it if called
+        # twice, which lets us assert on exact request count.
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            json={"scopes": [{"value": "project:read", "domain": "project", "action": "read"}]},
+            is_reusable=True,
+        )
+
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            results = await asyncio.gather(
+                get_or_fetch_grantable(ctx, client),
+                get_or_fetch_grantable(ctx, client),
+            )
+
+        assert results == [{"project:read"}, {"project:read"}]
+        # Exactly one network call despite two racing callers.
+        assert len(httpx_mock.get_requests(url=f"{_BASE_URL}/rbac/scopes")) == 1

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -13,8 +13,40 @@ from openfilter_mcp.scopes import (
     fetch_grantable_scopes,
     get_or_fetch_grantable,
     is_scope_granted,
+    parse_scope,
     suggest_grantable,
 )
+
+
+# ---------------------------------------------------------------------------
+# parse_scope
+# ---------------------------------------------------------------------------
+
+
+class TestParseScope:
+    def test_concrete_pair(self):
+        assert parse_scope("filterpipeline:read") == ("filterpipeline", "read")
+
+    def test_resource_wildcard(self):
+        assert parse_scope("filterpipeline:*") == ("filterpipeline", "*")
+
+    def test_admin_wildcard(self):
+        assert parse_scope("*:*") == ("*", "*")
+
+    def test_missing_colon_rejected(self):
+        assert parse_scope("no_colon") is None
+
+    def test_empty_resource_rejected(self):
+        assert parse_scope(":action") is None
+
+    def test_empty_action_rejected(self):
+        assert parse_scope("resource:") is None
+
+    def test_stray_colon_in_action_rejected(self):
+        assert parse_scope("a:b:c") is None
+
+    def test_empty_string_rejected(self):
+        assert parse_scope("") is None
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +105,7 @@ class TestIsScopeGranted:
         # A stray-colon scope is malformed and must be rejected regardless
         # of how broad the grant is — neither a resource-wildcard nor the
         # admin wildcard should paper over a bad shape.
+        assert parse_scope("a:b:c") is None
         assert not is_scope_granted("filterpipeline:read:extra", {"filterpipeline:*"})
         assert not is_scope_granted("filterpipeline:read:extra", {"*:*"})
         assert not is_scope_granted("filterpipeline:read:extra", {"filterpipeline:read:extra"})

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,6 +1,7 @@
 """Unit tests for openfilter_mcp.scopes."""
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -254,15 +255,32 @@ class TestGetOrFetchGrantable:
 
     async def test_concurrent_first_fetch_is_deduped(self, httpx_mock):
         """Two concurrent cold-cache callers must share a single
-        GET /rbac/scopes via the session-scoped lock + double-check."""
-        # Shared per-session state: get_state/set_state read/write this dict
+        GET /rbac/scopes via the request-scoped lock + double-check."""
+        # Shared per-request state: get_state/set_state read/write this dict
         # so both coroutines see each other's writes like the real ctx would.
         state: dict[str, object] = {}
 
         async def get_state(key):
             return state.get(key)
 
-        async def set_state(key, value):
+        async def set_state(key, value, *, serializable: bool = True):
+            # Mirror fastmcp's Context.set_state contract: when `serializable`
+            # is True (the default), the value is routed through a pydantic
+            # StateValue into key_value storage, which raises on
+            # non-json-round-trippable objects (e.g. asyncio.Lock). The real
+            # code catches the underlying SerializationError/ValueError and
+            # re-raises TypeError. We reproduce that here by round-tripping
+            # through json.dumps so tests catch regressions where a caller
+            # forgets to pass serializable=False for a non-serializable value.
+            if serializable:
+                try:
+                    json.dumps(value)
+                except TypeError as e:
+                    raise TypeError(
+                        f"Value for state key {key!r} is not serializable. "
+                        f"Use set_state({key!r}, value, serializable=False) to "
+                        f"store non-serializable values."
+                    ) from e
             state[key] = value
 
         ctx = MagicMock()

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -10,6 +10,7 @@ import pytest
 from openfilter_mcp.scopes import (
     GRANTABLE_SCOPES_KEY,
     ScopesUnavailable,
+    classify_rejection,
     fetch_grantable_scopes,
     get_or_fetch_grantable,
     is_scope_granted,
@@ -143,6 +144,69 @@ class TestSuggestGrantable:
 
     def test_empty_grantable(self):
         assert suggest_grantable("project:read", set()) is None
+
+
+# ---------------------------------------------------------------------------
+# classify_rejection
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyRejection:
+    """Each branch yields a distinct error message so agents can fix the half
+    that's actually wrong. The grantable set in these tests intentionally does
+    NOT contain '*:*' — classify_rejection is only called after is_scope_granted
+    returns False, so the admin-wildcard short-circuit is irrelevant here."""
+
+    GRANTABLE = {
+        "filterpipeline:read",
+        "filterpipeline:create",
+        "project:read",
+        "groundtruth:trigger",
+    }
+
+    def test_malformed_shape(self):
+        msg = classify_rejection("no_colon", self.GRANTABLE)
+        assert "expected 'resource:action'" in msg
+        assert "no_colon" in msg
+
+    def test_malformed_stray_colon(self):
+        # parse_scope rejects 'a:b:c' as malformed; the classifier must agree
+        # rather than falling through to "unknown resource 'a'".
+        msg = classify_rejection("filterpipeline:read:extra", self.GRANTABLE)
+        assert "expected 'resource:action'" in msg
+
+    def test_unknown_resource_lists_known_resources(self):
+        msg = classify_rejection("widget:read", self.GRANTABLE)
+        assert "unknown resource 'widget'" in msg
+        # Surfaced known resources are sorted for stable output.
+        assert "filterpipeline" in msg and "project" in msg and "groundtruth" in msg
+
+    def test_unknown_action_under_known_resource(self):
+        msg = classify_rejection("filterpipeline:delete", self.GRANTABLE)
+        assert "unknown action 'delete'" in msg
+        assert "for resource 'filterpipeline'" in msg
+        # The granted-actions list scopes to *this* resource, not the whole set.
+        assert "'create'" in msg and "'read'" in msg
+        assert "trigger" not in msg  # groundtruth's action shouldn't leak in
+
+    def test_admin_wildcard_request_distinguished(self):
+        msg = classify_rejection("*:*", self.GRANTABLE)
+        assert "admin scope" in msg
+        assert "'*:*'" in msg
+
+    def test_resource_wildcard_request_distinguished(self):
+        # Distinct from "unknown action '*'": user wants to escalate to a
+        # wildcard, not invoke a literal action named '*'.
+        msg = classify_rejection("filterpipeline:*", self.GRANTABLE)
+        assert "wildcard action" in msg
+        assert "'filterpipeline'" in msg
+
+    def test_cross_resource_wildcard_request_distinguished(self):
+        # `*:read` is the case called out in _SERVER_INSTRUCTIONS — it doesn't
+        # exist in the live scope set, so the only way to grant it is *:*.
+        msg = classify_rejection("*:read", self.GRANTABLE)
+        assert "cross-resource wildcard" in msg
+        assert "'*:*'" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,207 @@
+"""Unit tests for openfilter_mcp.scopes."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from openfilter_mcp.scopes import (
+    GRANTABLE_SCOPES_KEY,
+    ScopesUnavailable,
+    fetch_grantable_scopes,
+    get_or_fetch_grantable,
+    is_scope_granted,
+    suggest_grantable,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_scope_granted
+# ---------------------------------------------------------------------------
+
+
+class TestIsScopeGranted:
+    def test_exact_concrete_match(self):
+        assert is_scope_granted("filterpipeline:read", {"filterpipeline:read"})
+
+    def test_resource_wildcard_covers_concrete(self):
+        assert is_scope_granted("filterpipeline:read", {"filterpipeline:*"})
+
+    def test_admin_wildcard_covers_concrete(self):
+        assert is_scope_granted("filterpipeline:read", {"*:*"})
+
+    def test_admin_wildcard_covers_resource_wildcard(self):
+        assert is_scope_granted("filterpipeline:*", {"*:*"})
+
+    def test_concrete_miss(self):
+        assert not is_scope_granted(
+            "filterpipeline:delete",
+            {"filterpipeline:read", "filterpipeline:create"},
+        )
+
+    def test_other_resource_wildcard_does_not_cover(self):
+        assert not is_scope_granted("project:read", {"filterpipeline:*"})
+
+    def test_resource_wildcard_request_against_concrete_set_fails(self):
+        # Non-admin can't upgrade concrete tuples to a wildcard.
+        assert not is_scope_granted(
+            "filterpipeline:*",
+            {"filterpipeline:read", "filterpipeline:create", "filterpipeline:update"},
+        )
+
+    def test_admin_request_requires_admin_grant(self):
+        assert is_scope_granted("*:*", {"*:*"})
+        assert not is_scope_granted("*:*", {"filterpipeline:*", "project:*"})
+
+    def test_malformed_request_always_false(self):
+        assert not is_scope_granted("no_colon", {"*:*"})
+        assert not is_scope_granted(":action", {"*:*"})
+        assert not is_scope_granted("resource:", {"*:*"})
+        assert not is_scope_granted("", {"*:*"})
+
+    def test_sub_action_scopes(self):
+        # The drift bug this ticket fixes: sub-actions like 'start', 'trigger',
+        # 'upload' must be accepted when present in the grantable set.
+        assert is_scope_granted(
+            "pipelineinstance:start",
+            {"pipelineinstance:start", "pipelineinstance:stop"},
+        )
+        assert is_scope_granted("groundtruth:trigger", {"groundtruth:trigger"})
+        assert is_scope_granted("groundtruth:upload", {"groundtruth:*"})
+
+
+# ---------------------------------------------------------------------------
+# suggest_grantable
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestGrantable:
+    def test_typo_in_action(self):
+        grantable = {"filterpipeline:read", "filterpipeline:create"}
+        assert suggest_grantable("filterpipeline:raed", grantable) == "filterpipeline:read"
+
+    def test_typo_in_resource(self):
+        grantable = {"filterpipeline:read"}
+        # Close enough to filterpipeline; difflib should catch it.
+        assert suggest_grantable("filterpipelien:read", grantable) == "filterpipeline:read"
+
+    def test_no_reasonable_match(self):
+        assert suggest_grantable("zzzz:qqqq", {"filterpipeline:read"}) is None
+
+    def test_empty_grantable(self):
+        assert suggest_grantable("project:read", set()) is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_grantable_scopes
+# ---------------------------------------------------------------------------
+
+
+_BASE_URL = "https://api.example"
+
+
+@pytest.mark.asyncio
+class TestFetchGrantableScopes:
+    async def test_happy_path(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            json={
+                "scopes": [
+                    {"value": "filterpipeline:read", "domain": "filterpipeline", "action": "read"},
+                    {"value": "project:*", "domain": "project", "action": "*"},
+                ],
+            },
+        )
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            result = await fetch_grantable_scopes(client)
+        assert result == ["filterpipeline:read", "project:*"]
+
+    async def test_401_raises_with_status(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            status_code=401,
+            json={"error": "unauthenticated"},
+        )
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            with pytest.raises(ScopesUnavailable) as exc_info:
+                await fetch_grantable_scopes(client)
+        assert exc_info.value.status == 401
+
+    async def test_500_raises_with_status(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            status_code=500,
+            text="internal server error",
+        )
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            with pytest.raises(ScopesUnavailable) as exc_info:
+                await fetch_grantable_scopes(client)
+        assert exc_info.value.status == 500
+        assert "internal server error" in exc_info.value.detail
+
+    async def test_transport_error_raises_with_null_status(self, httpx_mock):
+        httpx_mock.add_exception(httpx.ConnectError("boom"))
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            with pytest.raises(ScopesUnavailable) as exc_info:
+                await fetch_grantable_scopes(client)
+        assert exc_info.value.status is None
+        assert "transport error" in exc_info.value.detail
+
+    async def test_missing_scopes_key_raises(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            json={"not_scopes": []},
+        )
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            with pytest.raises(ScopesUnavailable):
+                await fetch_grantable_scopes(client)
+
+    async def test_malformed_scope_entry_raises(self, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            json={"scopes": [{"domain": "project", "action": "read"}]},  # no 'value'
+        )
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            with pytest.raises(ScopesUnavailable):
+                await fetch_grantable_scopes(client)
+
+
+# ---------------------------------------------------------------------------
+# get_or_fetch_grantable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGetOrFetchGrantable:
+    async def test_fetches_on_cache_miss_and_persists(self, httpx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=None)
+        ctx.set_state = AsyncMock()
+        httpx_mock.add_response(
+            url=f"{_BASE_URL}/rbac/scopes",
+            json={"scopes": [{"value": "project:read", "domain": "project", "action": "read"}]},
+        )
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            result = await get_or_fetch_grantable(ctx, client)
+        assert result == {"project:read"}
+        ctx.set_state.assert_awaited_once_with(GRANTABLE_SCOPES_KEY, ["project:read"])
+
+    async def test_uses_cache_skips_fetch(self, httpx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=["cached:scope"])
+        ctx.set_state = AsyncMock()
+        # No httpx_mock.add_response — pytest-httpx errors if a request is made.
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            result = await get_or_fetch_grantable(ctx, client)
+        assert result == {"cached:scope"}
+        ctx.set_state.assert_not_called()
+
+    async def test_failure_not_cached(self, httpx_mock):
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value=None)
+        ctx.set_state = AsyncMock()
+        httpx_mock.add_response(url=f"{_BASE_URL}/rbac/scopes", status_code=500)
+        async with httpx.AsyncClient(base_url=_BASE_URL) as client:
+            with pytest.raises(ScopesUnavailable):
+                await get_or_fetch_grantable(ctx, client)
+        ctx.set_state.assert_not_called()

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -55,6 +55,14 @@ class TestIsScopeGranted:
         assert is_scope_granted("*:*", {"*:*"})
         assert not is_scope_granted("*:*", {"filterpipeline:*", "project:*"})
 
+    def test_cross_resource_wildcard_requires_admin(self):
+        # `*:read` is a cross-resource wildcard request — a concrete set of
+        # per-resource reads must NOT compose up to it, only `*:*` covers it.
+        # Pins the contract called out in server._SERVER_INSTRUCTIONS: there
+        # is no `*:read` shorthand in the live /rbac/scopes set.
+        assert is_scope_granted("*:read", {"*:*"})
+        assert not is_scope_granted("*:read", {"project:read", "filterpipeline:read"})
+
     def test_malformed_request_always_false(self):
         assert not is_scope_granted("no_colon", {"*:*"})
         assert not is_scope_granted(":action", {"*:*"})


### PR DESCRIPTION
- Replace hand-rolled {read,create,update,delete,*} validator with live GET /rbac/scopes fetch; cache the grantable set per MCP session via ctx.set_state
- Add list_grantable_scopes tool so agents can enumerate their role's grantable scope set instead of discovering it via validation errors
- Fix drift: PLAT-903 sub-action scopes (pipelineinstance:start|stop, groundtruth:trigger|upload|get-status|get-template-params) were rejected at the MCP layer despite being in policies.csv — now accepted when the caller's role covers them
- Graceful degradation when /rbac/scopes is unavailable: elicitation returns a loud error with the upstream status and detail; never silently falls back to a stale list (DT-134 acceptance)
- Clean up _SERVER_INSTRUCTIONS and request_scoped_token docstring: drop the stale '*:read' examples and the 'read,create,update,delete,*' enumeration that predate PLAT-903, point agents at list_grantable_scopes instead
- tests/conftest.py autouse fixture stubs get_or_fetch_grantable in the openfilter_mcp.server binding only, so existing tests stay green without per-test HTTP mocks while test_scopes.py still exercises the real code

Closes [DT-134](https://plainsight-ai.atlassian.net/browse/DT-134)

[DT-134]: https://plainsight-ai.atlassian.net/browse/DT-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ