### PR TITLE
fix(build): bump Cloud Run index-builder to Python 3.12

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
           --image=nvidia/cuda:12.4.0-devel-ubuntu22.04 \
           --command=bash \
           --set-env-vars=HF_TOKEN="$$HF_TOKEN" \
-          --args="-c,set -ex; apt-get update && apt-get install -y git gcc g++ cmake curl python3 python3-pip; curl -LsSf https://astral.sh/uv/install.sh | sh; curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts; export PATH=/root/.local/bin:/root/google-cloud-sdk/bin:\$$PATH; cd /tmp; gcloud storage cp gs://${_GCS_BUCKET}/builds/${BUILD_ID}/src.tar.gz .; tar xzf src.tar.gz; uv python install 3.11; uv sync --python 3.11 --group code-search; uv run index; tar czf idx.tar.gz indexes/ openfilter_repos_clones/; gcloud storage cp idx.tar.gz gs://${_GCS_BUCKET}/builds/${BUILD_ID}/idx.tar.gz"
+          --args="-c,set -ex; apt-get update && apt-get install -y git gcc g++ cmake curl python3 python3-pip; curl -LsSf https://astral.sh/uv/install.sh | sh; curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts; export PATH=/root/.local/bin:/root/google-cloud-sdk/bin:\$$PATH; cd /tmp; gcloud storage cp gs://${_GCS_BUCKET}/builds/${BUILD_ID}/src.tar.gz .; tar xzf src.tar.gz; uv python install 3.12; uv sync --python 3.12 --group code-search; uv run index; tar czf idx.tar.gz indexes/ openfilter_repos_clones/; gcloud storage cp idx.tar.gz gs://${_GCS_BUCKET}/builds/${BUILD_ID}/idx.tar.gz"
 
         gcloud run jobs execute index-builder --region=${_REGION} --wait
         gsutil cp gs://${_GCS_BUCKET}/builds/${BUILD_ID}/idx.tar.gz /workspace/


### PR DESCRIPTION
## Summary
- The index-builder Cloud Run job pinned Python 3.11 while the runtime Dockerfiles already use 3.12.
- `tree-sitter-language-pack` 1.6.x dropped abi3 wheels and the sdist, shipping only `cp312`/`cp314` wheels — so without a lockfile the 3.11 Cloud Run job re-resolved to 1.6.3 and had no compatible distribution, breaking release builds.
- Bumping the Cloud Run job to 3.12 aligns it with the runtime images and gets a compatible wheel.