### PR TITLE
fix(build): bump index-builder Cloud Run image to CUDA 13.2.1; surfac…

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
         gsutil cp /tmp/src.tar.gz gs://${_GCS_BUCKET}/builds/${BUILD_ID}/src.tar.gz
 
         gcloud run jobs update index-builder --region=${_REGION} \
-          --image=nvidia/cuda:12.4.0-devel-ubuntu22.04 \
+          --image=nvidia/cuda:13.2.1-devel-ubuntu22.04 \
           --command=bash \
           --set-env-vars=HF_TOKEN="$$HF_TOKEN" \
           --args="-c,set -ex; apt-get update && apt-get install -y git gcc g++ cmake curl python3 python3-pip; curl -LsSf https://astral.sh/uv/install.sh | sh; curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts; export PATH=/root/.local/bin:/root/google-cloud-sdk/bin:\$$PATH; cd /tmp; gcloud storage cp gs://${_GCS_BUCKET}/builds/${BUILD_ID}/src.tar.gz .; tar xzf src.tar.gz; uv python install 3.12; uv sync --python 3.12 --group code-search; uv run index; tar czf idx.tar.gz indexes/ openfilter_repos_clones/; gcloud storage cp idx.tar.gz gs://${_GCS_BUCKET}/builds/${BUILD_ID}/idx.tar.gz"

--- a/src/openfilter_mcp/preindex_repos.py
+++ b/src/openfilter_mcp/preindex_repos.py
@@ -1,5 +1,3 @@
-import sys
-
 import httpx
 import jq # Assuming python-jq library
 import os
@@ -8,10 +6,17 @@ import git
 import shutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+# Capture the actual ImportError. `code_context.indexing` re-exports
+# `code_context.embedding` which imports llama_cpp / torch / faiss —
+# any of those failing (e.g. CUDA-runtime mismatch) surfaces here as
+# ImportError and would otherwise collapse into "code-context is not
+# installed", which sends debugging in the wrong direction.
 try:
     from code_context.indexing import index_repository_direct
-except ImportError:
+    _import_error: BaseException | None = None
+except ImportError as e:
     index_repository_direct = None
+    _import_error = e
 
 MONOREPO_CLONE_DIR = "openfilter_repos_clones"
 
@@ -22,8 +27,17 @@ def preindex_openfilter_repos(org_name="plainsightai", name_filter=""):
     using code_context's core indexing function.
     """
     if index_repository_direct is None:
-        print("Error: code-context is not installed. Install with: uv sync --group code-search")
-        sys.exit(1)
+        # Re-raise with the original ImportError chained so the
+        # traceback shows the exact module/line that failed to import
+        # (typically inside code_context.embedding's llama_cpp/torch
+        # imports). The hint message helps the most common cause —
+        # missing install group — without hiding deeper failures.
+        raise RuntimeError(
+            "code_context.indexing failed to import. "
+            "If `code-context` itself is missing, run `uv sync --group code-search`. "
+            "If the package is installed, the chained ImportError below points at the "
+            "real failure (typically a torch/llama_cpp/CUDA runtime mismatch)."
+        ) from _import_error
 
     print(f"Fetching repositories for organization: {org_name}")
     headers = {"Accept": "application/vnd.github.v3+json"}


### PR DESCRIPTION
…e real ImportError

Cloud Build's main-branch trigger has been failing post-#50 with a misleading "code-context is not installed" error. Two issues, both fixed here:

1. **Image / runtime CUDA mismatch.** The Cloud Run job runs in `nvidia/cuda:12.4.0-devel-ubuntu22.04` but `uv sync --group code-search` resolves `torch==2.11.0`, whose wheels bundle CUDA 13.0 runtime libs (nvidia-cublas==13.1.0.3, nvidia-cuda-runtime ==13.0.96, nvidia-cudnn-cu13==9.19.0.56). At job startup `from llama_cpp import Llama` fails to load because llama_cpp was built against the container's 12.4 toolkit while torch's bundled libs expect 13.x. Bump to nvidia/cuda:13.2.1-devel- ubuntu22.04, the latest in the line torch was built against.

2. **Misleading error message** on import failure. preindex_repos.py caught `ImportError` from `from code_context.indexing import index_repository_direct` and printed "code-context is not installed" — but the actual failure was deeper in the chain (code_context.embedding → from llama_cpp import Llama). Surface the captured exception so the next runtime-deps regression diagnoses itself instead of pointing at a phantom missing package.