### PR TITLE
feat(auth): MCP OAuth 2.1 client for plainsight-api AS (DT-133)

### DIFF
--- a/src/openfilter_mcp/auth.py
+++ b/src/openfilter_mcp/auth.py
@@ -112,7 +112,17 @@ def decode_jwt_payload(token: str) -> Optional[Dict[str, Any]]:
 def get_org_id_from_token(token: str) -> Optional[str]:
     """Extract the organization ID from a JWT token.
 
-    Looks for organization_id in app_metadata or user_metadata.
+    Supports both supported JWT shapes:
+
+      - **Supabase session JWTs** put `organization_id` inside the
+        nested `app_metadata` (or `user_metadata`) object — that's
+        the legacy psctl-token path.
+      - **plainsight-api OAuth-issued JWTs** (DT-132) put `org_id`
+        as a flat top-level claim. The `app_metadata` shape isn't
+        applicable because OAuth tokens are issued by our AS, not by
+        Supabase.
+
+    Both are checked. Returns the first one found.
 
     Args:
         token: The JWT token string.
@@ -124,7 +134,12 @@ def get_org_id_from_token(token: str) -> Optional[str]:
     if not payload:
         return None
 
-    # Try app_metadata first, then user_metadata
+    # OAuth-issued tokens: flat `org_id` claim (DT-132).
+    flat = payload.get("org_id")
+    if flat:
+        return str(flat)
+
+    # Supabase session JWTs: nested under app_metadata / user_metadata.
     for key in ("app_metadata", "user_metadata"):
         metadata = payload.get(key, {})
         if isinstance(metadata, dict):

--- a/src/openfilter_mcp/entity_tools.py
+++ b/src/openfilter_mcp/entity_tools.py
@@ -915,46 +915,14 @@ class EntityToolsHandler:
         it overrides the default server token for this request. The scoped token's
         org_id is also used automatically.
 
-        SECURITY INVARIANT — DO NOT BREAK:
-        The Authorization header on outbound *entity-op* calls comes
-        from EITHER the session-scoped token (set by request_scoped_token
-        after explicit user approval) OR the user's static psctl /
-        OPENFILTER_TOKEN — NEVER from the OAuth Bearer that authenticated
-        this request to /mcp.
-
-        Bootstrap exception: server.py's `_resolve_bootstrap_auth` may
-        consume the FastMCP-context OAuth bearer for the ONE specific
-        call where it's the only credential available — the
-        /api-tokens POST that creates the session-scoped token in the
-        first place. Without that exception, OAuth-only deployments
-        (no psctl token on disk) can't bootstrap the elicitation flow
-        and are stuck at PermissionError forever. The bootstrap path
-        STILL drives elicitation: the user approves the narrower
-        scopes via `request_scoped_token`, and the resulting
-        session-bound token is what unlocks entity ops below.
-
-        OAuth Bearer auth on the MCP ingress (via RemoteAuthProvider in
-        server.py) signals "this caller is allowed to invoke MCP tools";
-        it does NOT substitute for the user's explicit per-session scope-
-        elicitation for entity ops. An agent operating under a broad
-        OAuth token (e.g. Claude Code with the user's full grantable
-        set) MUST still drive request_scoped_token before any entity
-        op, so the user gets to approve a narrower set of scopes for
-        this particular session (principle of least privilege, defense-
-        in-depth against an LLM deciding to write where it was told to
-        read).
-
-        If you're adding a new code path HERE (entity ops) and find
-        yourself reaching for `request.headers["authorization"]` or
-        `ctx.request_context.access_token` to populate the outbound
-        Authorization header, STOP. That collapses the ingress-auth
-        and outbound-auth layers and silently bypasses the elicitation
-        gate. The right pattern is always: scoped session token (set
-        by user-approved request_scoped_token) → fall back to
-        get_auth_token() (psctl or env) → fall back to the explicit
-        PermissionError below. The bootstrap exception is restricted
-        to `_resolve_bootstrap_auth` in server.py and is the ONLY
-        sanctioned consumer of the request bearer for outbound auth.
+        Outbound Authorization: scoped session token (user-approved via
+        request_scoped_token) → static psctl/OPENFILTER_TOKEN → explicit
+        PermissionError. The request OAuth bearer is intentionally NOT in
+        this chain; consuming it here would bypass the elicitation gate.
+        The single sanctioned exception is `server._resolve_bootstrap_auth`
+        for the /api-tokens POST that creates the session-scoped token.
+        That invariant is enforced by `tests/test_security_invariant.py`,
+        which AST-scans this file for the forbidden patterns.
 
         Args:
             org_id: Optional cross-tenant org ID override.

--- a/src/openfilter_mcp/entity_tools.py
+++ b/src/openfilter_mcp/entity_tools.py
@@ -915,6 +915,47 @@ class EntityToolsHandler:
         it overrides the default server token for this request. The scoped token's
         org_id is also used automatically.
 
+        SECURITY INVARIANT — DO NOT BREAK:
+        The Authorization header on outbound *entity-op* calls comes
+        from EITHER the session-scoped token (set by request_scoped_token
+        after explicit user approval) OR the user's static psctl /
+        OPENFILTER_TOKEN — NEVER from the OAuth Bearer that authenticated
+        this request to /mcp.
+
+        Bootstrap exception: server.py's `_resolve_bootstrap_auth` may
+        consume the FastMCP-context OAuth bearer for the ONE specific
+        call where it's the only credential available — the
+        /api-tokens POST that creates the session-scoped token in the
+        first place. Without that exception, OAuth-only deployments
+        (no psctl token on disk) can't bootstrap the elicitation flow
+        and are stuck at PermissionError forever. The bootstrap path
+        STILL drives elicitation: the user approves the narrower
+        scopes via `request_scoped_token`, and the resulting
+        session-bound token is what unlocks entity ops below.
+
+        OAuth Bearer auth on the MCP ingress (via RemoteAuthProvider in
+        server.py) signals "this caller is allowed to invoke MCP tools";
+        it does NOT substitute for the user's explicit per-session scope-
+        elicitation for entity ops. An agent operating under a broad
+        OAuth token (e.g. Claude Code with the user's full grantable
+        set) MUST still drive request_scoped_token before any entity
+        op, so the user gets to approve a narrower set of scopes for
+        this particular session (principle of least privilege, defense-
+        in-depth against an LLM deciding to write where it was told to
+        read).
+
+        If you're adding a new code path HERE (entity ops) and find
+        yourself reaching for `request.headers["authorization"]` or
+        `ctx.request_context.access_token` to populate the outbound
+        Authorization header, STOP. That collapses the ingress-auth
+        and outbound-auth layers and silently bypasses the elicitation
+        gate. The right pattern is always: scoped session token (set
+        by user-approved request_scoped_token) → fall back to
+        get_auth_token() (psctl or env) → fall back to the explicit
+        PermissionError below. The bootstrap exception is restricted
+        to `_resolve_bootstrap_auth` in server.py and is the ONLY
+        sanctioned consumer of the request bearer for outbound auth.
+
         Args:
             org_id: Optional cross-tenant org ID override.
             ctx: FastMCP Context for accessing session state.

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -527,9 +527,17 @@ def create_mcp_server() -> FastMCP:
     try:
         client = create_authenticated_client(require_token=False)
     except AuthenticationError as exc:
-        # require_token=False means this branch can't actually fire today,
-        # but keep it for symmetry in case a future require_token=True
-        # path lands.
+        # require_token=False shouldn't raise on a missing token, so an
+        # AuthenticationError here means something deeper went wrong
+        # (e.g. transport refused to mint a default-headers client).
+        # Honor the documented REQUIRE_AUTH fail-fast contract.
+        if require_auth:
+            raise SystemExit(
+                f"REQUIRE_AUTH is set but authentication failed: {exc}\n"
+                "Provide a valid token via OPENFILTER_TOKEN env var, mount a "
+                "psctl token file, or enable OAuth-only mode by setting "
+                "OAUTH_AS_URL."
+            ) from exc
         logger.warning("create_authenticated_client raised unexpectedly: %s", exc)
 
     if require_auth and not has_auth and auth_mode != "OAuth-only (per-request bearer)":

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -510,10 +510,12 @@ def create_mcp_server() -> FastMCP:
 
     Returns:
         A FastMCP server instance with entity CRUD tools plus code search tools.
-        If no authentication token is available, only code search tools are registered.
+        Entity tools register whenever the OpenAPI spec is reachable — auth is
+        resolved per-request inside each handler, not at registration time. If
+        the OpenAPI fetch fails, only code search tools are registered.
 
     Raises:
-        SystemExit: If REQUIRE_AUTH is set and no valid token is found.
+        SystemExit: If REQUIRE_AUTH is set and no authentication path is available.
     """
     # Create base MCP server. `auth` is None unless OAUTH_AS_URL is set,
     # in which case FastMCP mounts the RFC 9728 protected-resource

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -41,7 +41,6 @@ from openfilter_mcp.auth import (
     get_auth_token,
     get_effective_org_id,
     is_plainsight_employee,
-    read_psctl_token,
     AuthenticationError,
     TokenRefreshTransport,
 )
@@ -389,6 +388,54 @@ Note: By default, all API operations require a scoped token. You MUST call reque
 """.strip()
 
 
+def _resolve_bootstrap_auth() -> str | None:
+    """Resolve the credential to use for the /api-tokens bootstrap call.
+
+    Order of preference:
+
+      1. `get_auth_token()` — psctl token file or OPENFILTER_TOKEN env.
+         Long-lived primary credential when present.
+      2. FastMCP request-context OAuth bearer — the user's just-
+         OAuth-approved access token, available in OAuth-only
+         deployments where (1) is empty.
+
+    Returns the raw bearer string or None if neither path has a
+    credential. Used ONLY by `_create_and_activate_token` for the
+    /api-tokens elicitation-bootstrap call. Entity ops do NOT
+    consume this — they go through `entity_tools._get_request_headers`
+    which requires a session-scoped token (the elicitation gate).
+    That gate stays intact regardless of which bootstrap credential
+    was used here.
+
+    The security invariant that entity ops MUST NOT consume the request
+    bearer is enforced at test time by `tests/test_security_invariant.py`,
+    which AST-scans every entity-op handler for the anti-pattern.
+    """
+    token = get_auth_token()
+    if token:
+        return token
+    # Fall through to the OAuth bearer if we're running OAuth-only.
+    # Importing the dependency here keeps the existing psctl-only
+    # deployment path from pulling in the FastMCP auth module.
+    try:
+        from fastmcp.server.dependencies import get_access_token  # type: ignore[import-not-found]
+    except ImportError:
+        # Older fastmcp without OAuth dependency module — psctl path only.
+        return None
+    try:
+        access = get_access_token()
+    except Exception as exc:
+        # get_access_token() reads from a contextvar populated by FastMCP's
+        # auth middleware. If the middleware isn't installed, the var is
+        # missing, or the context is corrupted, surface it at debug level
+        # so OAuth-only deploys can diagnose silent bootstrap failures.
+        logger.debug("get_access_token() failed during bootstrap: %s", exc)
+        return None
+    if access is not None:
+        return access.token
+    return None
+
+
 def _build_oauth_provider() -> Any:
     """Construct a FastMCP RemoteAuthProvider when OAUTH_AS_URL is set,
     otherwise return None and let the existing psctl-token Bearer path
@@ -504,10 +551,15 @@ def create_mcp_server() -> FastMCP:
     client = None
     openapi_spec = None
     has_auth = bool(token)
+    # Control-flow signal for the REQUIRE_AUTH gate below: OAuth-only mode
+    # is when there's no startup token AND OAUTH_AS_URL is configured (the
+    # per-request bearer satisfies REQUIRE_AUTH). `auth_mode` is purely a
+    # log label — never compare it to gate behavior.
+    oauth_only_mode = not token and bool(os.getenv("OAUTH_AS_URL"))
     auth_mode = (
         "psctl/env token"
         if token
-        else "OAuth-only (per-request bearer)" if os.getenv("OAUTH_AS_URL") else "none"
+        else "OAuth-only (per-request bearer)" if oauth_only_mode else "none"
     )
 
     try:
@@ -540,7 +592,7 @@ def create_mcp_server() -> FastMCP:
             ) from exc
         logger.warning("create_authenticated_client raised unexpectedly: %s", exc)
 
-    if require_auth and not has_auth and auth_mode != "OAuth-only (per-request bearer)":
+    if require_auth and not has_auth and not oauth_only_mode:
         raise SystemExit(
             "REQUIRE_AUTH is set but no authentication path is available.\n"
             "Provide a valid token via OPENFILTER_TOKEN env var, mount a psctl "
@@ -549,7 +601,7 @@ def create_mcp_server() -> FastMCP:
         )
 
     if not has_auth:
-        if auth_mode == "OAuth-only (per-request bearer)":
+        if oauth_only_mode:
             logger.info(
                 "no startup credential found; running in OAuth-only mode "
                 "(per-request bearer auth via OAUTH_AS_URL=%s)",
@@ -721,40 +773,6 @@ def create_mcp_server() -> FastMCP:
     # avoiding 409 conflicts with tokens from other sessions.
     import secrets as _secrets
     _session_id = _secrets.token_hex(4)  # e.g. "a1b2c3d4"
-
-    def _resolve_bootstrap_auth() -> str | None:
-        """Resolve the credential to use for the /api-tokens bootstrap call.
-
-        Order of preference:
-
-          1. `get_auth_token()` — psctl token file or OPENFILTER_TOKEN env.
-             Long-lived primary credential when present.
-          2. FastMCP request-context OAuth bearer — the user's just-
-             OAuth-approved access token, available in OAuth-only
-             deployments where (1) is empty.
-
-        Returns the raw bearer string or None if neither path has a
-        credential. Used ONLY by `_create_and_activate_token` for the
-        /api-tokens elicitation-bootstrap call. Entity ops do NOT
-        consume this — they go through `entity_tools._get_request_headers`
-        which requires a session-scoped token (the elicitation gate).
-        That gate stays intact regardless of which bootstrap credential
-        was used here.
-        """
-        token = get_auth_token()
-        if token:
-            return token
-        # Fall through to the OAuth bearer if we're running OAuth-only.
-        # Importing the dependency here keeps the existing psctl-only
-        # deployment path from pulling in the FastMCP auth module.
-        try:
-            from fastmcp.server.dependencies import get_access_token  # type: ignore[import-not-found]
-            access = get_access_token()
-            if access is not None:
-                return access.token
-        except Exception:
-            pass
-        return None
 
     async def _create_and_activate_token(
         ctx: Context,

--- a/src/openfilter_mcp/server.py
+++ b/src/openfilter_mcp/server.py
@@ -239,31 +239,53 @@ class SchemaStrippingTransport(httpx.AsyncBaseTransport):
         return response
 
 
-def create_authenticated_client(timeout: float = 30.0):
-    """Create an authenticated async HTTP client for Plainsight API.
+def create_authenticated_client(timeout: float = 30.0, *, require_token: bool = False):
+    """Create an async HTTP client for Plainsight API.
 
-    Supports cross-tenant operations for Plainsight employees via PS_TARGET_ORG_ID.
+    Auth resolution model:
+
+      1. If a startup token is available (psctl token file or
+         OPENFILTER_TOKEN env), bind it as the client's default
+         Authorization header.
+      2. If not, return a client with NO Authorization default. Per-
+         request handlers (entity_tools._get_request_headers,
+         request_scoped_token's bootstrap path) override Authorization
+         on each call from session-scoped state, the user's primary
+         token, or the FastMCP-context OAuth bearer (whichever is
+         appropriate for that specific call). This is the load-bearing
+         change for OAuth-only deployments where there's no startup
+         token at all but every authenticated request carries a bearer.
+
+    Supports cross-tenant operations for Plainsight employees via
+    PS_TARGET_ORG_ID.
 
     Args:
         timeout: Request timeout in seconds.
+        require_token: If True, raise AuthenticationError when no
+            startup token is available (legacy behavior; only set this
+            from explicit psctl-only deployment paths). Defaults to
+            False so OAuth-only mode constructs a no-default-auth
+            client and tools register normally.
 
     Returns:
-        Configured httpx.AsyncClient instance with schema-stripping middleware
-        and automatic 401 retry via token refresh.
+        Configured httpx.AsyncClient instance with schema-stripping
+        middleware and automatic 401 retry via token refresh.
 
     Raises:
-        AuthenticationError: If no valid token is available.
+        AuthenticationError: If `require_token=True` and no token is
+            available.
     """
     token = get_auth_token()
-    if not token:
+    if not token and require_token:
         raise AuthenticationError("No authentication token available")
 
-    headers = {"Authorization": f"Bearer {token}"}
-
-    # Use effective org ID (supports cross-tenant for Plainsight employees)
-    org_id = get_effective_org_id(token)
-    if org_id:
-        headers["X-Scope-OrgID"] = org_id
+    headers: Dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        # Use effective org ID (supports cross-tenant for Plainsight employees)
+        org_id = get_effective_org_id(token)
+        if org_id:
+            headers["X-Scope-OrgID"] = org_id
 
     # Create transport chain: base -> token refresh -> schema stripping
     # Token refresh handles 401s by refreshing the token and retrying
@@ -367,6 +389,75 @@ Note: By default, all API operations require a scoped token. You MUST call reque
 """.strip()
 
 
+def _build_oauth_provider() -> Any:
+    """Construct a FastMCP RemoteAuthProvider when OAUTH_AS_URL is set,
+    otherwise return None and let the existing psctl-token Bearer path
+    (auth.py) handle requests as before.
+
+    The provider does two things FastMCP wires up automatically once
+    `auth=` is non-None:
+
+      1. Mounts `/.well-known/oauth-protected-resource` (RFC 9728) so
+         MCP clients discover the AS by querying *this* server first
+         rather than the cascade of fallbacks they currently 404 on
+         when they hit a server without this endpoint.
+      2. Returns 401 with a `WWW-Authenticate: Bearer ... resource_metadata="<url>"`
+         header on any unauthenticated request, pointing the client at
+         the protected-resource document above.
+
+    Token validation: ES256 (ECDSA P-256) JWTs against the AS's JWKS.
+    Plainsight API (DT-132) issues these — see internal/oauth/service/
+    keystore.go for the JWK shape we consume here. EdDSA was rejected
+    upstream specifically because FastMCP's stock JWTVerifier hardcodes
+    its alg allowlist and excludes it; ES256 is in the allowlist.
+
+    Audience: RFC 8707 resource-indicator-aware MCP clients (Claude Code,
+    MCP Inspector) pass `resource=<this-server>/mcp` at /authorize time,
+    and plainsight-api binds the JWT `aud` claim to that resource. So we
+    accept BOTH `<resource_url>/mcp` (the spec'd binding) AND `<as_url>`
+    (the iss-fallback for older clients that don't pass resource=). The
+    JWTVerifier accepts a list of audiences and validates that the token's
+    aud matches at least one. OAUTH_AUDIENCE overrides this list entirely
+    if the deployment needs custom values.
+    """
+    as_url = os.getenv("OAUTH_AS_URL")
+    if not as_url:
+        return None
+
+    # Imports are local so the existing psctl-token deployment path
+    # doesn't pull in the auth provider chain it never uses.
+    from fastmcp.server.auth import RemoteAuthProvider  # type: ignore[import-not-found]
+    from fastmcp.server.auth.providers.jwt import JWTVerifier  # type: ignore[import-not-found]
+
+    as_url = as_url.rstrip("/")
+    resource_url = os.getenv(
+        "OAUTH_RESOURCE_URL",
+        f"http://localhost:{os.getenv('PORT', '3000')}",
+    ).rstrip("/")
+    # Default audience set: the spec'd RFC 8707 binding (resource_url +
+    # "/mcp", which is what the protected-resource doc advertises and
+    # what RemoteAuthProvider broadcasts as the resource) plus the AS
+    # URL for iss-fallback compatibility. Either passes verification.
+    audience_env = os.getenv("OAUTH_AUDIENCE")
+    if audience_env:
+        audience: str | list[str] = [a.strip() for a in audience_env.split(",") if a.strip()]
+    else:
+        audience = [f"{resource_url}/mcp", as_url]
+
+    verifier = JWTVerifier(
+        jwks_uri=f"{as_url}/.well-known/jwks.json",
+        issuer=as_url,
+        audience=audience,
+        algorithm="ES256",
+    )
+    return RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[as_url],
+        base_url=resource_url,
+        resource_name="OpenFilter MCP",
+    )
+
+
 def create_mcp_server() -> FastMCP:
     """Create the MCP server with entity-based API tools and code search tools.
 
@@ -377,8 +468,14 @@ def create_mcp_server() -> FastMCP:
     Raises:
         SystemExit: If REQUIRE_AUTH is set and no valid token is found.
     """
-    # Create base MCP server
-    mcp = FastMCP(name="OpenFilter MCP", instructions=_SERVER_INSTRUCTIONS)
+    # Create base MCP server. `auth` is None unless OAUTH_AS_URL is set,
+    # in which case FastMCP mounts the RFC 9728 protected-resource
+    # endpoints + 401 WWW-Authenticate dance automatically.
+    mcp = FastMCP(
+        name="OpenFilter MCP",
+        instructions=_SERVER_INSTRUCTIONS,
+        auth=_build_oauth_provider(),
+    )
 
     # Register approval routes on the MCP server (reuses port 3000, works in Docker)
     approval_registry = register_approval_routes(mcp)
@@ -388,41 +485,86 @@ def create_mcp_server() -> FastMCP:
     # slim server would register zero tools and silently do nothing.
     require_auth = os.getenv("REQUIRE_AUTH", "false").lower() == "true"
 
-    # Try to create authenticated client and load OpenAPI tools
-    # If no token is available, we'll still create a server with code search tools
+    # OpenAPI + entity-spec are PUBLIC endpoints on plainsight-api — they
+    # don't require authentication. Fetch them unconditionally so entity
+    # tools can register regardless of whether a startup credential is
+    # available. Auth is resolved per-request inside the tool handlers
+    # (session-scoped token from elicitation > psctl/env startup token >
+    # FastMCP-context OAuth bearer for the request_scoped_token bootstrap
+    # path), not at registration time.
+    #
+    # Earlier this was gated on `if token:` AND wrapped in a swallow-the-
+    # exception block, so a deployment with no psctl token (OAuth-only)
+    # silently registered zero tools — Claude Code saw an empty catalog
+    # via tools/list and looked broken end-to-end with no log line
+    # explaining why. Decoupling here also surfaces openapi-fetch
+    # failures loudly via the regular httpx exception path instead of
+    # hiding them behind has_auth=False.
     token = get_auth_token()
     client = None
     openapi_spec = None
-    has_auth = False
+    has_auth = bool(token)
+    auth_mode = (
+        "psctl/env token"
+        if token
+        else "OAuth-only (per-request bearer)" if os.getenv("OAUTH_AS_URL") else "none"
+    )
 
-    if token:
-        try:
-            client = create_authenticated_client()
-            openapi_spec = get_openapi_spec()
-            has_auth = True
-        except AuthenticationError as exc:
-            if require_auth:
-                raise SystemExit(
-                    "REQUIRE_AUTH is set but authentication failed: "
-                    f"{exc}\n"
-                    "Provide a valid token via OPENFILTER_TOKEN env var "
-                    "or mount a psctl token file."
-                ) from exc
-            # Token was available but invalid - proceed without API tools
-
-    if require_auth and not has_auth:
-        raise SystemExit(
-            "REQUIRE_AUTH is set but no authentication token was found.\n"
-            "Provide a valid token via OPENFILTER_TOKEN env var "
-            "or mount a psctl token file (~/.config/plainsight/token)."
+    try:
+        openapi_spec = get_openapi_spec()
+    except Exception as exc:
+        logger.warning(
+            "openapi.json fetch failed at startup against %s — entity tools will not register: %s",
+            PLAINSIGHT_API_URL,
+            exc,
         )
 
-    # Register entity-based CRUD tools if authenticated
+    # Construct an http client even when there's no startup token — it's
+    # used by entity tool handlers per-request with session-scoped
+    # Authorization headers, and by request_scoped_token's bootstrap path
+    # (which resolves Authorization at call time, not at client
+    # construction).
+    try:
+        client = create_authenticated_client(require_token=False)
+    except AuthenticationError as exc:
+        # require_token=False means this branch can't actually fire today,
+        # but keep it for symmetry in case a future require_token=True
+        # path lands.
+        logger.warning("create_authenticated_client raised unexpectedly: %s", exc)
+
+    if require_auth and not has_auth and auth_mode != "OAuth-only (per-request bearer)":
+        raise SystemExit(
+            "REQUIRE_AUTH is set but no authentication path is available.\n"
+            "Provide a valid token via OPENFILTER_TOKEN env var, mount a psctl "
+            "token file (~/.config/plainsight/token), or enable OAuth-only "
+            "mode by setting OAUTH_AS_URL."
+        )
+
+    if not has_auth:
+        if auth_mode == "OAuth-only (per-request bearer)":
+            logger.info(
+                "no startup credential found; running in OAuth-only mode "
+                "(per-request bearer auth via OAUTH_AS_URL=%s)",
+                os.getenv("OAUTH_AS_URL"),
+            )
+        else:
+            logger.warning(
+                "no startup credential AND no OAUTH_AS_URL — entity ops "
+                "will fail at request time with PermissionError. Set "
+                "OPENFILTER_TOKEN or run `psctl login`."
+            )
+
+    # Register entity-based CRUD tools whenever the OpenAPI spec is
+    # available — auth is no longer the registration gate. The handlers
+    # themselves enforce the elicitation gate (session-scoped token
+    # required for entity ops) at runtime.
     registry = None
     entity_handler = None
-    if has_auth and openapi_spec and client:
+    if openapi_spec and client is not None:
         entity_spec = get_entity_spec()
-        registry, entity_handler = register_entity_tools(mcp, client, openapi_spec, entity_spec=entity_spec, approval_registry=approval_registry)
+        registry, entity_handler = register_entity_tools(
+            mcp, client, openapi_spec, entity_spec=entity_spec, approval_registry=approval_registry
+        )
 
     # =========================================================================
     # Code Search Tools (manually defined - not part of Plainsight API)
@@ -477,10 +619,12 @@ def create_mcp_server() -> FastMCP:
         )
 
     # =========================================================================
-    # Generic Polling Tool (only available with authentication)
+    # Generic Polling Tool (only registered when openapi succeeded — its
+    # implementation calls back into entity handlers which themselves
+    # enforce per-request auth resolution).
     # =========================================================================
 
-    if has_auth and client:
+    if client is not None and entity_handler is not None:
 
         def _get_cross_tenant_headers(org_id: str | None) -> Dict[str, str] | None:
             """Get headers for cross-tenant access if allowed."""
@@ -570,6 +714,40 @@ def create_mcp_server() -> FastMCP:
     import secrets as _secrets
     _session_id = _secrets.token_hex(4)  # e.g. "a1b2c3d4"
 
+    def _resolve_bootstrap_auth() -> str | None:
+        """Resolve the credential to use for the /api-tokens bootstrap call.
+
+        Order of preference:
+
+          1. `get_auth_token()` — psctl token file or OPENFILTER_TOKEN env.
+             Long-lived primary credential when present.
+          2. FastMCP request-context OAuth bearer — the user's just-
+             OAuth-approved access token, available in OAuth-only
+             deployments where (1) is empty.
+
+        Returns the raw bearer string or None if neither path has a
+        credential. Used ONLY by `_create_and_activate_token` for the
+        /api-tokens elicitation-bootstrap call. Entity ops do NOT
+        consume this — they go through `entity_tools._get_request_headers`
+        which requires a session-scoped token (the elicitation gate).
+        That gate stays intact regardless of which bootstrap credential
+        was used here.
+        """
+        token = get_auth_token()
+        if token:
+            return token
+        # Fall through to the OAuth bearer if we're running OAuth-only.
+        # Importing the dependency here keeps the existing psctl-only
+        # deployment path from pulling in the FastMCP auth module.
+        try:
+            from fastmcp.server.dependencies import get_access_token  # type: ignore[import-not-found]
+            access = get_access_token()
+            if access is not None:
+                return access.token
+        except Exception:
+            pass
+        return None
+
     async def _create_and_activate_token(
         ctx: Context,
         http_client: httpx.AsyncClient,
@@ -586,7 +764,15 @@ def create_mcp_server() -> FastMCP:
         Returns:
             Success dict with status "active", or error dict on failure.
         """
+        # /api-tokens needs a credential. The startup-bound client may
+        # have no default Authorization header (OAuth-only mode); fall
+        # back to the request bearer if so. Either way the resulting
+        # session-scoped token is what subsequent entity ops use, so the
+        # elicitation gate is preserved.
+        bootstrap_token = _resolve_bootstrap_auth()
         org_headers = {"X-Scope-OrgID": effective_org_id}
+        if bootstrap_token:
+            org_headers["Authorization"] = f"Bearer {bootstrap_token}"
         payload = {
             "name": name,
             "scopes": scope_list,
@@ -652,7 +838,13 @@ def create_mcp_server() -> FastMCP:
     # At most one pending approval per MCP session — a new request auto-cancels the previous.
     _pending_approvals: Dict[str, Any] = {}  # keyed by ctx.session_id
 
-    if has_auth and client:
+    # Scoped-token tools register whenever an http client exists — auth
+    # for the bootstrap /api-tokens call resolves at request time via
+    # _resolve_bootstrap_auth (psctl/env > FastMCP-context OAuth bearer).
+    # The elicitation gate (session-bound scoped token required for
+    # entity ops) lives downstream in entity_tools._get_request_headers
+    # and is unaffected.
+    if client is not None:
 
         @mcp.tool()
         async def list_grantable_scopes(ctx: Context | None = None) -> Dict[str, Any]:
@@ -820,13 +1012,15 @@ def create_mcp_server() -> FastMCP:
                 if "Method not found" not in err_msg and "not supported" not in err_msg:
                     raise
 
-                # Compute org_id now so it's available when the approval completes
+                # Compute org_id now so it's available when the approval completes.
+                # Use _resolve_bootstrap_auth so OAuth-only deployments (no psctl
+                # token) can still derive org_id from the request bearer's flat
+                # `org_id` claim (DT-132).
                 effective_org_id = org_id
                 if not effective_org_id:
-                    token = read_psctl_token() or get_auth_token()
+                    token = _resolve_bootstrap_auth()
                     if not token:
                         return {"error": "No authentication token available."}
-                    effective_org_id = get_effective_org_id(token)
                     effective_org_id = get_effective_org_id(token)
                 if not effective_org_id:
                     return {"error": "Cannot determine organization ID from current token."}
@@ -879,13 +1073,13 @@ def create_mcp_server() -> FastMCP:
             if not approved:
                 return {"status": "denied", "message": "User denied the token request."}
 
-            # Get the effective org ID
+            # Get the effective org ID. _resolve_bootstrap_auth covers both the
+            # legacy psctl/env path and the OAuth-only request-bearer fallback.
             effective_org_id = org_id
             if not effective_org_id:
-                token = read_psctl_token() or get_auth_token()
+                token = _resolve_bootstrap_auth()
                 if not token:
                     return {"error": "No authentication token available."}
-                effective_org_id = get_effective_org_id(token)
                 effective_org_id = get_effective_org_id(token)
             if not effective_org_id:
                 return {"error": "Cannot determine organization ID from current token."}

--- a/tests/test_approval_e2e.py
+++ b/tests/test_approval_e2e.py
@@ -113,7 +113,7 @@ def mcp_server() -> FastMCP:
             "openfilter_mcp.server.create_authenticated_client",
             return_value=_make_mock_client(),
         ),
-        patch("openfilter_mcp.server.read_psctl_token", return_value="test-token"),
+        patch("openfilter_mcp.entity_tools.read_psctl_token", return_value="test-token"),
     ):
         from openfilter_mcp.server import create_mcp_server
 
@@ -137,7 +137,7 @@ def _make_mcp_server_with_client(mock_client):
             "openfilter_mcp.server.create_authenticated_client",
             return_value=mock_client,
         ),
-        patch("openfilter_mcp.server.read_psctl_token", return_value="test-token"),
+        patch("openfilter_mcp.entity_tools.read_psctl_token", return_value="test-token"),
     ):
         from openfilter_mcp.server import create_mcp_server
 

--- a/tests/test_openapi_integration.py
+++ b/tests/test_openapi_integration.py
@@ -175,29 +175,59 @@ class TestMCPServerCreation:
 
     def test_create_mcp_server_require_auth_fails_without_token(self):
         """Should raise SystemExit when REQUIRE_AUTH=true and no token is available."""
-        with patch.dict(os.environ, {"REQUIRE_AUTH": "true"}):
+        # `get_openapi_spec` is now fetched unconditionally at startup
+        # (decoupled from auth), so without a mock httpx.get would block
+        # for the full 30s timeout in offline / CI environments before
+        # the try/except catches it. Mock to keep this test hermetic.
+        mock_spec = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {},
+        }
+        with patch.dict(os.environ, {"REQUIRE_AUTH": "true"}, clear=False):
+            os.environ.pop("OAUTH_AS_URL", None)
             with patch("openfilter_mcp.server.get_auth_token", return_value=None):
-                from openfilter_mcp.server import create_mcp_server
+                with patch(
+                    "openfilter_mcp.server.get_openapi_spec",
+                    return_value=mock_spec,
+                ):
+                    from openfilter_mcp.server import create_mcp_server
 
-                with pytest.raises(SystemExit, match="REQUIRE_AUTH is set"):
-                    create_mcp_server()
+                    with pytest.raises(SystemExit, match="REQUIRE_AUTH is set"):
+                        create_mcp_server()
 
     def test_create_mcp_server_require_auth_fails_on_invalid_token(self):
-        """Should raise SystemExit when REQUIRE_AUTH=true and token is invalid."""
+        """Should raise SystemExit when REQUIRE_AUTH=true and client construction fails.
+
+        With `require_token=False` the AuthenticationError handler path
+        is dead under normal operation, but if a transport-level failure
+        ever surfaces it as AuthenticationError, REQUIRE_AUTH must still
+        fail-fast rather than serve a half-broken catalog.
+        """
         # Import AuthenticationError from server module to ensure class identity
         # matches the except clause (avoids beartype import-hook mismatch).
         from openfilter_mcp.server import AuthenticationError
 
-        with patch.dict(os.environ, {"REQUIRE_AUTH": "true"}):
+        mock_spec = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {},
+        }
+        with patch.dict(os.environ, {"REQUIRE_AUTH": "true"}, clear=False):
+            os.environ.pop("OAUTH_AS_URL", None)
             with patch("openfilter_mcp.server.get_auth_token", return_value="bad-token"):
                 with patch(
-                    "openfilter_mcp.server.create_authenticated_client",
-                    side_effect=AuthenticationError("token expired"),
+                    "openfilter_mcp.server.get_openapi_spec",
+                    return_value=mock_spec,
                 ):
-                    from openfilter_mcp.server import create_mcp_server
+                    with patch(
+                        "openfilter_mcp.server.create_authenticated_client",
+                        side_effect=AuthenticationError("token expired"),
+                    ):
+                        from openfilter_mcp.server import create_mcp_server
 
-                    with pytest.raises(SystemExit, match="authentication failed"):
-                        create_mcp_server()
+                        with pytest.raises(SystemExit, match="authentication failed"):
+                            create_mcp_server()
 
     def test_create_mcp_server_require_auth_succeeds_with_token(self):
         """Should start normally when REQUIRE_AUTH=true and a valid token exists."""
@@ -330,6 +360,207 @@ class TestCodeSearchTools:
         ):
             with pytest.raises(FileNotFoundError):
                 _real_path("../../../etc/passwd")
+
+
+class TestBuildOAuthProvider:
+    """Tests for `_build_oauth_provider` — the OAuth gate constructor.
+
+    Audience list, issuer, algorithm, and JWKS URI all need to be correct
+    for tokens to verify, so each piece of the provider config gets its
+    own assertion here.
+    """
+
+    def test_returns_none_when_oauth_as_url_unset(self):
+        """No OAUTH_AS_URL → return None, server falls back to psctl path."""
+        from openfilter_mcp.server import _build_oauth_provider
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OAUTH_AS_URL", None)
+            assert _build_oauth_provider() is None
+
+    def test_default_audience_list_when_unset(self):
+        """Default audience accepts BOTH the RFC 8707 binding (resource_url+/mcp)
+        AND the AS URL (iss-fallback for clients without resource=)."""
+        from openfilter_mcp.server import _build_oauth_provider
+
+        env = {
+            "OAUTH_AS_URL": "https://api.example.com",
+            "OAUTH_RESOURCE_URL": "https://mcp.example.com",
+            "PORT": "3000",
+        }
+        env_clear_keys = ["OAUTH_AUDIENCE"]
+        with patch.dict(os.environ, env, clear=False):
+            for key in env_clear_keys:
+                os.environ.pop(key, None)
+            mock_verifier = MagicMock()
+            mock_provider = MagicMock()
+            with patch(
+                "fastmcp.server.auth.providers.jwt.JWTVerifier",
+                return_value=mock_verifier,
+            ) as mock_verifier_cls:
+                with patch(
+                    "fastmcp.server.auth.RemoteAuthProvider",
+                    return_value=mock_provider,
+                ) as mock_provider_cls:
+                    result = _build_oauth_provider()
+
+        assert result is mock_provider
+        verifier_kwargs = mock_verifier_cls.call_args.kwargs
+        assert verifier_kwargs["audience"] == [
+            "https://mcp.example.com/mcp",
+            "https://api.example.com",
+        ]
+        assert verifier_kwargs["issuer"] == "https://api.example.com"
+        assert verifier_kwargs["algorithm"] == "ES256"
+        assert verifier_kwargs["jwks_uri"] == "https://api.example.com/.well-known/jwks.json"
+
+        provider_kwargs = mock_provider_cls.call_args.kwargs
+        assert provider_kwargs["authorization_servers"] == ["https://api.example.com"]
+        assert provider_kwargs["base_url"] == "https://mcp.example.com"
+
+    def test_oauth_audience_env_override(self):
+        """OAUTH_AUDIENCE replaces the default audience list entirely."""
+        from openfilter_mcp.server import _build_oauth_provider
+
+        env = {
+            "OAUTH_AS_URL": "https://api.example.com",
+            "OAUTH_RESOURCE_URL": "https://mcp.example.com",
+            "OAUTH_AUDIENCE": "custom-aud, second-aud  ,",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch(
+                "fastmcp.server.auth.providers.jwt.JWTVerifier"
+            ) as mock_verifier_cls:
+                with patch("fastmcp.server.auth.RemoteAuthProvider"):
+                    _build_oauth_provider()
+
+        verifier_kwargs = mock_verifier_cls.call_args.kwargs
+        # Stripped of whitespace; empty trailing token dropped.
+        assert verifier_kwargs["audience"] == ["custom-aud", "second-aud"]
+
+    def test_trailing_slashes_stripped(self):
+        """as_url and resource_url shouldn't accumulate trailing slashes
+        when env values are pasted with one."""
+        from openfilter_mcp.server import _build_oauth_provider
+
+        env = {
+            "OAUTH_AS_URL": "https://api.example.com/",
+            "OAUTH_RESOURCE_URL": "https://mcp.example.com/",
+        }
+        env_clear_keys = ["OAUTH_AUDIENCE"]
+        with patch.dict(os.environ, env, clear=False):
+            for key in env_clear_keys:
+                os.environ.pop(key, None)
+            with patch(
+                "fastmcp.server.auth.providers.jwt.JWTVerifier"
+            ) as mock_verifier_cls:
+                with patch(
+                    "fastmcp.server.auth.RemoteAuthProvider"
+                ) as mock_provider_cls:
+                    _build_oauth_provider()
+
+        verifier_kwargs = mock_verifier_cls.call_args.kwargs
+        assert verifier_kwargs["jwks_uri"] == "https://api.example.com/.well-known/jwks.json"
+        assert verifier_kwargs["issuer"] == "https://api.example.com"
+        # Default audience uses the cleaned values.
+        assert "https://mcp.example.com/mcp" in verifier_kwargs["audience"]
+        provider_kwargs = mock_provider_cls.call_args.kwargs
+        assert provider_kwargs["base_url"] == "https://mcp.example.com"
+
+
+class TestResolveBootstrapAuth:
+    """Tests for `_resolve_bootstrap_auth` — the credential precedence
+    used by /api-tokens when bootstrapping the elicitation flow.
+
+    The order (psctl/env > FastMCP-context OAuth bearer) is a security
+    invariant: in mixed deployments the long-lived primary credential
+    must take precedence so that a request with a narrow OAuth bearer
+    can't be elevated to using a broad psctl token. (And in OAuth-only
+    deployments, the OAuth bearer is the only available credential.)
+    """
+
+    def test_returns_psctl_env_token_when_present(self):
+        """Primary credential takes precedence over the OAuth fallback."""
+        from openfilter_mcp.server import _resolve_bootstrap_auth
+
+        with patch(
+            "openfilter_mcp.server.get_auth_token", return_value="psctl-token"
+        ):
+            # Even if the OAuth dependency is importable, it must not be consulted.
+            with patch(
+                "fastmcp.server.dependencies.get_access_token"
+            ) as mock_get_access:
+                result = _resolve_bootstrap_auth()
+
+        assert result == "psctl-token"
+        mock_get_access.assert_not_called()
+
+    def test_falls_through_to_oauth_bearer_when_no_psctl(self):
+        """OAuth-only mode: psctl is empty → consult fastmcp request bearer."""
+        from openfilter_mcp.server import _resolve_bootstrap_auth
+
+        mock_access = MagicMock()
+        mock_access.token = "oauth-bearer-xyz"
+
+        with patch("openfilter_mcp.server.get_auth_token", return_value=None):
+            with patch(
+                "fastmcp.server.dependencies.get_access_token",
+                return_value=mock_access,
+            ):
+                result = _resolve_bootstrap_auth()
+
+        assert result == "oauth-bearer-xyz"
+
+    def test_returns_none_when_oauth_dependency_missing(self):
+        """Older fastmcp without `dependencies` module: psctl-only mode."""
+        from openfilter_mcp.server import _resolve_bootstrap_auth
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "fastmcp.server.dependencies":
+                raise ImportError("no such module")
+            return real_import(name, *args, **kwargs)
+
+        with patch("openfilter_mcp.server.get_auth_token", return_value=None):
+            with patch.object(builtins, "__import__", side_effect=fake_import):
+                result = _resolve_bootstrap_auth()
+
+        assert result is None
+
+    def test_returns_none_when_oauth_context_missing(self):
+        """Importable but no request context active → return None gracefully."""
+        from openfilter_mcp.server import _resolve_bootstrap_auth
+
+        with patch("openfilter_mcp.server.get_auth_token", return_value=None):
+            with patch(
+                "fastmcp.server.dependencies.get_access_token",
+                return_value=None,
+            ):
+                result = _resolve_bootstrap_auth()
+
+        assert result is None
+
+    def test_logs_debug_on_unexpected_failure(self, caplog):
+        """Unexpected runtime failures in get_access_token() get logged at
+        DEBUG so OAuth-mode operators can diagnose silent breakage."""
+        import logging as _logging
+        from openfilter_mcp.server import _resolve_bootstrap_auth
+
+        with patch("openfilter_mcp.server.get_auth_token", return_value=None):
+            with patch(
+                "fastmcp.server.dependencies.get_access_token",
+                side_effect=RuntimeError("missing request context"),
+            ):
+                with caplog.at_level(_logging.DEBUG, logger="openfilter_mcp.server"):
+                    result = _resolve_bootstrap_auth()
+
+        assert result is None
+        assert any(
+            "get_access_token() failed during bootstrap" in rec.message
+            for rec in caplog.records
+        )
 
 
 class TestSchemaStripping:

--- a/tests/test_openapi_integration.py
+++ b/tests/test_openapi_integration.py
@@ -97,8 +97,23 @@ class TestAuthenticatedClient:
         assert client.headers["Authorization"] == "Bearer simple-token"
         assert "X-Scope-OrgID" not in client.headers
 
-    def test_create_authenticated_client_raises_without_token(self):
-        """Should raise AuthenticationError when no token available."""
+    def test_create_authenticated_client_no_token_does_not_raise(self):
+        """Default behavior: no token -> client without Authorization default.
+
+        Per-request handlers resolve auth at call time (session-scoped
+        token, psctl/env, or FastMCP-context OAuth bearer), so client
+        construction must succeed without a startup token.
+        """
+        with patch("openfilter_mcp.server.get_auth_token", return_value=None):
+            from openfilter_mcp.server import create_authenticated_client
+
+            client = create_authenticated_client()
+
+        assert "Authorization" not in client.headers
+        assert "X-Scope-OrgID" not in client.headers
+
+    def test_create_authenticated_client_require_token_raises(self):
+        """Legacy require_token=True path still raises when no token."""
         with patch("openfilter_mcp.server.get_auth_token", return_value=None):
             from openfilter_mcp.server import (
                 create_authenticated_client,
@@ -106,24 +121,40 @@ class TestAuthenticatedClient:
             )
 
             with pytest.raises(AuthenticationError):
-                create_authenticated_client()
+                create_authenticated_client(require_token=True)
 
 
 class TestMCPServerCreation:
     """Tests for MCP server creation from OpenAPI spec."""
 
     def test_create_mcp_server_without_token_still_works(self):
-        """Should create MCP server without token (no OpenAPI tools, no polling)."""
+        """Without a startup token, server creation must succeed and
+        register entity + polling tools.
+
+        Auth is resolved per-request inside tool handlers (session-scoped
+        token from elicitation > psctl/env > FastMCP-context OAuth
+        bearer), so the registration path no longer gates on a startup
+        credential. The `if not has_auth` branch only logs a warning.
+        """
+        mock_spec = {
+            "openapi": "3.1.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {},
+        }
         with patch.dict(os.environ, {"REQUIRE_AUTH": "false"}):
             with patch("openfilter_mcp.server.get_auth_token", return_value=None):
                 with patch(
-                    "openfilter_mcp.server.get_latest_index_name",
-                    return_value="test-index",
+                    "openfilter_mcp.server.get_openapi_spec",
+                    return_value=mock_spec,
                 ):
-                    from openfilter_mcp.server import create_mcp_server
+                    with patch(
+                        "openfilter_mcp.server.get_latest_index_name",
+                        return_value="test-index",
+                    ):
+                        from openfilter_mcp.server import create_mcp_server
 
-                    # This should NOT raise an exception
-                    mcp = create_mcp_server()
+                        # This should NOT raise an exception
+                        mcp = create_mcp_server()
 
         tool_names = _get_tool_names(mcp)
 
@@ -134,11 +165,13 @@ class TestMCPServerCreation:
             assert "get_chunk" in tool_names
             assert "read_file" in tool_names
 
-        # OpenAPI tools should NOT be available (no auth)
-        assert "list_projects" not in tool_names
+        # Entity tools register regardless of startup token — auth is
+        # enforced per-request by the handlers themselves.
+        assert "list_entity_types" in tool_names
+        assert "list_entities" in tool_names
 
-        # Polling tool should NOT be available (requires auth)
-        assert "poll_until_change" not in tool_names
+        # Polling tool registers alongside entity tools.
+        assert "poll_until_change" in tool_names
 
     def test_create_mcp_server_require_auth_fails_without_token(self):
         """Should raise SystemExit when REQUIRE_AUTH=true and no token is available."""

--- a/tests/test_security_invariant.py
+++ b/tests/test_security_invariant.py
@@ -141,10 +141,12 @@ def _walk_functions(tree: ast.AST):
                 # Allowlisted: don't yield this function and don't recurse inside.
                 continue
             yield node
-        # Recurse into classes, conditional blocks, etc. so nested functions
-        # don't slip past unchecked.
-        if isinstance(node, (ast.ClassDef, ast.If, ast.Try, ast.With, ast.AsyncWith)):
-            yield from _walk_functions(node)
+            # Don't recurse into the function body; _function_violates handles it.
+            continue
+        # Recurse into every other compound node — class bodies, control-flow
+        # blocks, exception handlers, match cases, etc. — so a function
+        # defined in any of them is still reached.
+        yield from _walk_functions(node)
 
 
 def test_src_root_exists():

--- a/tests/test_security_invariant.py
+++ b/tests/test_security_invariant.py
@@ -1,0 +1,232 @@
+"""AST-enforced security invariants for the OAuth bootstrap exception.
+
+The PR that introduced OAuth-mode bootstrap (DT-133) carved out a
+single sanctioned consumer of the request-bound OAuth Bearer for
+outbound auth: `openfilter_mcp.server._resolve_bootstrap_auth`. Every
+other code path — entity ops in particular — must derive outbound
+Authorization from the session-scoped token (set by user-approved
+`request_scoped_token`) or the static psctl/OPENFILTER_TOKEN.
+Collapsing these layers silently bypasses the elicitation gate: an
+agent operating under a broad OAuth token would skip per-session
+scope approval and reach API surfaces the user never consented to.
+
+These tests scan the Python AST of `src/openfilter_mcp/` for the
+anti-patterns the invariant forbids. The previous implementation
+documented the rule in a 30-line comment in `entity_tools.py`; this
+file enforces it in CI so a future contributor can't unknowingly
+regress it.
+
+Forbidden patterns (in any function except `_resolve_bootstrap_auth`):
+
+  1. `ctx.request_context.access_token` — a deep attribute chain that
+     pulls the FastMCP context's authenticated token.
+  2. Subscripting `request.headers` for an authorization key — reading
+     the raw inbound Authorization header off the request object.
+  3. Calling `get_access_token()` imported from any `fastmcp` module —
+     the FastMCP dependency that returns the request's verified bearer.
+
+Allowlist: only `_resolve_bootstrap_auth` (and any function nested
+inside it) may use these. The allowlist is enforced by name, not by
+file, so moving the function to another module without updating the
+allowlist will NOT silently grant blanket permission to that module.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "openfilter_mcp"
+
+# Functions allowed to consume the request OAuth bearer for outbound auth.
+# Any function lexically nested inside one of these names is also exempt.
+_ALLOWLISTED_FUNCTIONS = frozenset(
+    {
+        "_resolve_bootstrap_auth",
+    }
+)
+
+# Authorization-header key variants that count as "reading the inbound auth".
+_AUTH_HEADER_KEYS = frozenset({"authorization", "Authorization", "AUTHORIZATION"})
+
+
+def _iter_python_files() -> list[Path]:
+    """Walk src/openfilter_mcp/ and return every .py file."""
+    return sorted(p for p in SRC_ROOT.rglob("*.py") if p.is_file())
+
+
+def _attribute_chain(node: ast.AST) -> list[str] | None:
+    """Flatten an `a.b.c` Attribute chain to ['a','b','c']; None if not pure."""
+    parts: list[str] = []
+    cur: ast.AST = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        parts.reverse()
+        return parts
+    return None
+
+
+def _function_violates(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Return human-readable descriptions of any anti-patterns inside `func`.
+
+    The walk descends into nested expressions but treats nested function
+    definitions whose name is allowlisted as a transparent boundary: their
+    body is not scanned (the allowlist applies recursively).
+    """
+    violations: list[str] = []
+
+    def visit(node: ast.AST) -> None:
+        # Don't descend into a nested function whose name is itself allowlisted —
+        # the recursion guarantees nested functions stay on the same allowlist.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name in _ALLOWLISTED_FUNCTIONS:
+                return
+
+        # Pattern 1: <anything>.request_context.access_token
+        if isinstance(node, ast.Attribute) and node.attr == "access_token":
+            chain = _attribute_chain(node)
+            if chain and len(chain) >= 2 and chain[-2] == "request_context":
+                violations.append(
+                    f"line {node.lineno}: reads `{'.'.join(chain)}` "
+                    "(forbidden — collapses ingress OAuth bearer onto outbound auth)"
+                )
+
+        # Pattern 2: request.headers[...] subscripted by an auth key
+        if isinstance(node, ast.Subscript):
+            value_chain = _attribute_chain(node.value)
+            if value_chain and len(value_chain) >= 2 and value_chain[-1] == "headers":
+                key = node.slice
+                if isinstance(key, ast.Constant) and key.value in _AUTH_HEADER_KEYS:
+                    violations.append(
+                        f"line {node.lineno}: reads "
+                        f"`{'.'.join(value_chain)}[{key.value!r}]` "
+                        "(forbidden — collapses raw inbound Authorization header onto outbound auth)"
+                    )
+
+        # Pattern 3: calling get_access_token() — the FastMCP request-bearer accessor
+        if isinstance(node, ast.Call):
+            callee = node.func
+            chain = _attribute_chain(callee) if isinstance(callee, ast.Attribute) else None
+            if isinstance(callee, ast.Name) and callee.id == "get_access_token":
+                violations.append(
+                    f"line {node.lineno}: calls `get_access_token()` "
+                    "(forbidden — only `_resolve_bootstrap_auth` may consume the request OAuth bearer)"
+                )
+            elif chain and chain[-1] == "get_access_token":
+                violations.append(
+                    f"line {node.lineno}: calls `{'.'.join(chain)}()` "
+                    "(forbidden — only `_resolve_bootstrap_auth` may consume the request OAuth bearer)"
+                )
+
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    for stmt in func.body:
+        visit(stmt)
+
+    return violations
+
+
+def _walk_functions(tree: ast.AST):
+    """Yield every (top-level or nested) FunctionDef / AsyncFunctionDef in `tree`,
+    skipping ones (and their descendants) whose name is allowlisted."""
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name in _ALLOWLISTED_FUNCTIONS:
+                # Allowlisted: don't yield this function and don't recurse inside.
+                continue
+            yield node
+        # Recurse into classes, conditional blocks, etc. so nested functions
+        # don't slip past unchecked.
+        if isinstance(node, (ast.ClassDef, ast.If, ast.Try, ast.With, ast.AsyncWith)):
+            yield from _walk_functions(node)
+
+
+def test_src_root_exists():
+    """Sanity check: the test wouldn't catch anything if the path were wrong."""
+    assert SRC_ROOT.is_dir(), f"expected source tree at {SRC_ROOT}"
+    assert any(SRC_ROOT.rglob("*.py")), "no Python files found under src/openfilter_mcp"
+
+
+@pytest.mark.parametrize(
+    "src_path",
+    _iter_python_files(),
+    ids=lambda p: p.relative_to(SRC_ROOT).as_posix(),
+)
+def test_no_forbidden_oauth_bearer_consumption(src_path: Path):
+    """Every function in src/openfilter_mcp/ except `_resolve_bootstrap_auth`
+    must avoid the documented anti-patterns. If you have a legitimate need
+    to consume the request OAuth bearer for outbound auth, add the helper
+    function to `_ALLOWLISTED_FUNCTIONS` here AND extend the security
+    invariant doc in `_resolve_bootstrap_auth`'s docstring — drift between
+    the two is exactly what this test exists to catch."""
+    tree = ast.parse(src_path.read_text(encoding="utf-8"), filename=str(src_path))
+
+    failures: list[str] = []
+    for func in _walk_functions(tree):
+        problems = _function_violates(func)
+        if problems:
+            qualname = f"{src_path.relative_to(SRC_ROOT)}::{func.name}"
+            for p in problems:
+                failures.append(f"{qualname} — {p}")
+
+    assert not failures, (
+        "Security invariant violation — entity-op / non-bootstrap code is "
+        "consuming the request OAuth bearer for outbound auth:\n  - "
+        + "\n  - ".join(failures)
+    )
+
+
+def test_resolve_bootstrap_auth_is_the_only_allowlisted_function():
+    """Pin the allowlist so adding a new exemption requires touching this
+    test (and therefore the security invariant doc in tandem)."""
+    assert _ALLOWLISTED_FUNCTIONS == frozenset({"_resolve_bootstrap_auth"})
+
+
+def test_allowlisted_function_actually_uses_get_access_token():
+    """Lock in that `_resolve_bootstrap_auth` is the function that pulls
+    the request OAuth bearer — if it stops doing so the allowlist entry
+    is dead and should be removed.
+
+    This is the *positive* form of the invariant: not just 'no one else
+    does this' but 'precisely one place does, and we know which.'
+    """
+    server_path = SRC_ROOT / "server.py"
+    tree = ast.parse(server_path.read_text(encoding="utf-8"))
+
+    found_function = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_resolve_bootstrap_auth"
+        ):
+            found_function = node
+            break
+
+    assert found_function is not None, (
+        "_resolve_bootstrap_auth not found in server.py — either it was "
+        "renamed (update _ALLOWLISTED_FUNCTIONS) or removed (drop the "
+        "allowlist entry entirely)."
+    )
+
+    uses_get_access_token = False
+    for node in ast.walk(found_function):
+        if isinstance(node, ast.Call):
+            callee = node.func
+            if isinstance(callee, ast.Name) and callee.id == "get_access_token":
+                uses_get_access_token = True
+                break
+            chain = _attribute_chain(callee) if isinstance(callee, ast.Attribute) else None
+            if chain and chain[-1] == "get_access_token":
+                uses_get_access_token = True
+                break
+
+    assert uses_get_access_token, (
+        "_resolve_bootstrap_auth no longer calls get_access_token(). The "
+        "allowlist entry is now dead — drop it from _ALLOWLISTED_FUNCTIONS."
+    )


### PR DESCRIPTION
## Summary

Adds opt-in RFC 9728 protected-resource discovery + ES256 JWT validation against plainsight-api's OAuth 2.1 AS (DT-132). When `OAUTH_AS_URL` is set, MCP clients (Claude Code, Inspector, etc.) can discover the AS, drive RFC 7591 dynamic registration + RFC 6749 §4.1 authz-code+PKCE, and reach `/mcp` with a verified Bearer. When it's unset the server falls back to the existing psctl-token path and behaves identically to before — no behavior change for non-OAuth deployments.

## What MCP clients see (OAuth-only mode)

- `GET /.well-known/oauth-protected-resource/mcp` → 200 with `{"resource": "<self>/mcp", "authorization_servers": ["<AS>"], ...}`. Per the MCP 2025-06-18 spec the metadata lives under the per-MCP- endpoint suffix; this replaces the cascade of `/.well-known/oauth-authorization-server`, `openid-configuration`, etc. that clients currently 404 on.
- `POST /mcp` without Bearer → 401 with `WWW-Authenticate: Bearer ..., resource_metadata="<self>/.well-known/oauth-protected-resource/mcp"`.
- Validated Bearer → MCP handshake / tool calls run normally.

## Token validation

Uses FastMCP's stock `JWTVerifier` with `algorithm="ES256"` and `jwks_uri=<AS>/.well-known/jwks.json`. The AS-side commit that switched signing alg from EdDSA → ES256 was specifically to support this verifier (its alg allowlist hardcodes RS/ES/PS/HS variants and rejects EdDSA).

**Audience accepts a list.** plainsight-api falls back `aud=iss` when `/authorize` did not bind a `resource=` parameter (RFC 8707), but resource-aware clients (Claude Code) DO pass `resource=` so the JWT `aud` lands on `<self>/mcp`. JWTVerifier was previously configured with `audience=<AS>` only, which rejected RFC-8707-bound tokens ("audience mismatch ... 'http://localhost:3000/mcp', expected 'http://localhost:8081'") and surfaced as "Authentication successful, but server reconnection failed." Default audience is now `[<self>/mcp, <AS>]` covering both shapes; either matches. `OAUTH_AUDIENCE` accepts a comma-separated override.

## Tool registration decoupled from startup-token validation

Two real bugs fixed:

1. **Silent failure**: previous startup path swallowed `AuthenticationError` from `create_authenticated_client()` / `get_openapi_spec()` and set `has_auth=False`. Server booted looking healthy with zero entity tools and no log line explaining why.
2. **OAuth-only deployments registered zero tools**: `has_auth` was computed from psctl-file/env at startup, but in OAuth-only mode the only credential is the per-request Bearer. Tools stayed unregistered regardless of how many authenticated requests landed afterward.

Redesign:

- `/openapi.json` and `/entity-spec` are PUBLIC on plainsight-api — fetch them unconditionally at startup. Tools register whenever the openapi fetch succeeds; the previous if-token gate conflated "discovery is possible" with "I have a credential to call APIs."
- `create_authenticated_client(require_token=False)` returns a client with no `Authorization` default header when no startup token exists. Per-request handlers override `Authorization` from session state, the user's primary token, or the FastMCP-context Bearer.
- New `_resolve_bootstrap_auth()` resolves the credential for the ONE call that needs auth before elicitation has run: `POST /api-tokens` inside `request_scoped_token`. Order of preference: psctl/env > FastMCP-context Bearer.
- Loud INFO/WARNING when running OAuth-only without a startup credential, and when openapi.json fetch fails. The previous swallow ran in complete silence.

## Elicitation gate preserved

The elicitation gate (`PermissionError` on entity ops without a session-bound scoped token) is structurally preserved over OAuth. `get_auth_token()` reads only from `OPENFILTER_TOKEN` env or the psctl token file — it does NOT pull from the request's OAuth Bearer. So an agent running under a broad OAuth Bearer still hits `PermissionError` until it drives `request_scoped_token` and the user approves a narrower set via elicitation/browser-approval.

`_resolve_bootstrap_auth` is the only sanctioned consumer of the request Bearer for outbound calls and is documented as such with a "DO NOT BREAK" comment in `entity_tools.py` that names the exact anti-pattern (reading `request.headers["authorization"]` / `ctx.request_context.access_token` into outbound headers) that would silently collapse the layers and let an agent skip elicitation.

## OAuth-shape org_id resolution

plainsight-api OAuth-issued JWTs carry `org_id` as a flat top-level claim, not nested under `app_metadata.organization_id` like Supabase session JWTs. `get_org_id_from_token` now checks the flat claim first and falls back to the legacy nested shape. The `request_scoped_token` bootstrap path also now uses `_resolve_bootstrap_auth()` instead of `read_psctl_token() || get_auth_token()` so OAuth-only deployments can derive `org_id` from the request Bearer.

## Configuration

| Var | Default | Purpose |
|---|---|---|
| `OAUTH_AS_URL` | unset (disables OAuth) | plainsight-api AS base URL | | `OAUTH_RESOURCE_URL` | `http://localhost:$PORT` | advertised in protected-resource doc; must match the externally-reachable URL of this server | | `OAUTH_AUDIENCE` | `<self>/mcp,<AS>` | comma-separated accept-list for JWT `aud` |

## Test plan

- [x] **psctl-token mode** (existing behavior): `tools/list` still returns 13 tools; entity ops authenticate with the stored token.
- [x] **OAuth-only mode** (no psctl, no `OPENFILTER_TOKEN`, `OAUTH_AS_URL` set): Claude Code OAuth flow completes end-to-end against a local plainsight-api at `:8080` + this server at `:3000`. `tools/list` returns the same 13 tools; `list_entity_types` succeeds without a session token; entity ops route through the elicitation gate (PermissionError until `request_scoped_token` runs).
- [x] **Audience binding**: tokens minted with `resource=http://localhost:3000/mcp` AND tokens minted without `resource=` (aud=iss-fallback) both verify and reach `/mcp`.
- [x] **End-to-end with Claude Code**: register → authorize → consent → token → MCP `initialize` → `request_scoped_token` (read-only) → `list_entities organization` returns the user's org.