### PR TITLE
fix(build): move release-tag version lookup to cloud build step 0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,6 +36,11 @@ steps:
         # Auto-detect slim-only from tag name (e.g. v1.0.0-slim-dev)
         SLIM_ONLY="${_SLIM_ONLY}"
         if [[ "${TAG_NAME}" == *slim* ]]; then SLIM_ONLY=true; fi
+        # Compute the DockerHub :latest{,-slim} version up here in cloud-sdk
+        # (which has python3) so the docker steps don't need any JSON tooling.
+        # Runs before the SLIM_ONLY exit so slim-only builds also get the file.
+        python3 scripts/lookup_latest_version.py --latest-tag latest --suffix= > /workspace/.latest_version
+        python3 scripts/lookup_latest_version.py --latest-tag latest-slim --suffix=-slim > /workspace/.latest_version-slim
         if [[ "$$SLIM_ONLY" == "true" ]]; then echo "SLIM_ONLY: skipping index build"; exit 0; fi
         tar czf /tmp/src.tar.gz --exclude='.git' --exclude='indexes' .
         gsutil cp /tmp/src.tar.gz gs://${_GCS_BUCKET}/builds/${BUILD_ID}/src.tar.gz

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -103,28 +103,10 @@ else
     echo "Version tag build: ${TAG_NAME} (${DOCKERFILE})"
     NEW_VERSION=$(echo "${TAG_NAME}" | sed 's/^v//')
 
-    # Fetch current latest version from DockerHub (python3 instead of jq — not in cloud-builders/docker)
-    LATEST_DIGEST=$(curl -s "https://hub.docker.com/v2/repositories/${_DOCKERHUB_REPO}/tags/${LATEST_TAG}" | \
-      python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("images",[{}])[0].get("digest",""))' 2>/dev/null)
-
-    CURRENT_VERSION=""
-    if [[ -n "${LATEST_DIGEST}" ]]; then
-      CURRENT_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/${_DOCKERHUB_REPO}/tags?page_size=100" | \
-        python3 -c '
-import sys, json, re
-data = json.load(sys.stdin)
-digest = "'"${LATEST_DIGEST}"'"
-suffix = "'"${TAG_SUFFIX}"'"
-pat = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+" + re.escape(suffix) + r"$")
-for tag in data.get("results", []):
-    if any(img.get("digest") == digest for img in tag.get("images", [])):
-        name = tag["name"]
-        if pat.match(name):
-            print(re.sub(r"^v", "", name.removesuffix(suffix)))
-            break
-' | head -1)
-    fi
-    CURRENT_VERSION="${CURRENT_VERSION:-0.0.0}"
+    # The DockerHub :latest{,-slim} version is computed in cloud build step 0
+    # (see scripts/lookup_latest_version.py) and dropped at /workspace as a flat
+    # file. Falls back to 0.0.0 for local runs that bypass step 0.
+    CURRENT_VERSION=$(cat "/workspace/.latest_version${TAG_SUFFIX}" 2>/dev/null || echo "0.0.0")
     echo "Current latest: ${CURRENT_VERSION}, New: ${NEW_VERSION}"
 
     # Semver compare: true if $1 >= $2

--- a/scripts/lookup_latest_version.py
+++ b/scripts/lookup_latest_version.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Look up the version that a DockerHub :<tag> currently points to.
+
+Fetches the digest of `<repo>:<latest-tag>`, scans the tag list for sibling
+tags pointing at the same digest, filters to ones ending with `--suffix` whose
+stem (minus 'v' and minus suffix) is pure X.Y.Z, prints the highest such
+version. Prints `0.0.0` if nothing matches or DockerHub is unreachable, so
+callers can compare unconditionally.
+
+Stdlib-only (urllib + json) — runs in `gcr.io/google.com/cloudsdktool/cloud-sdk`
+without any extra installs.
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+# Hardcoded — Cloud Build only ever calls this for openfilter-mcp's release-tag
+# pipeline. Lift to an arg if a second repo ever needs the same lookup.
+REPO = "plainsightai/openfilter-mcp"
+
+
+def _fetch_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return json.load(resp)
+
+
+def lookup(latest_tag: str, suffix: str) -> str:
+    base = f"https://hub.docker.com/v2/repositories/{REPO}"
+
+    try:
+        digest = (_fetch_json(f"{base}/tags/{latest_tag}").get("images") or [{}])[0].get("digest", "")
+    except Exception:
+        return "0.0.0"
+    if not digest:
+        return "0.0.0"
+
+    try:
+        tags = _fetch_json(f"{base}/tags?page_size=100").get("results", [])
+    except Exception:
+        return "0.0.0"
+
+    versions: list[tuple[int, int, int]] = []
+    for tag in tags:
+        if not any(img.get("digest") == digest for img in tag.get("images", [])):
+            continue
+        name = tag.get("name", "")
+        if not name.endswith(suffix):
+            continue
+        stem = name.removeprefix("v").removesuffix(suffix)
+        parts = stem.split(".")
+        if len(parts) != 3 or not all(p.isdigit() for p in parts):
+            continue
+        versions.append(tuple(int(p) for p in parts))  # type: ignore[arg-type]
+
+    if not versions:
+        return "0.0.0"
+    return ".".join(str(p) for p in max(versions))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--latest-tag", required=True, help="e.g. latest or latest-slim")
+    p.add_argument("--suffix", default="", help="e.g. -slim (empty for the GPU build)")
+    args = p.parse_args()
+    print(lookup(args.latest_tag, args.suffix))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Tagged release builds are currently broken on `main`. A test build of `v0.2.2` (slim-only, dry-run, build [`296cfe7d-…`](https://console.cloud.google.com/cloud-build/builds;region=us-west1/296cfe7d-5bf2-4c81-a97d-cb8f599c214a?project=934113377363)) fails at step 2 with:

```
Step #2: Version tag build: v0.2.2 (Dockerfile.slim)
Step #2: Traceback (most recent call last):
Step #2:   File "<string>", line 11, in <module>
Step #2: AttributeError: 'str' object has no attribute 'removesuffix'
```

`scripts/docker-build.sh`'s release-tag branch parses DockerHub JSON inline with `python3 -c '...'`, using `str.removesuffix` — which is Python 3.9+. The `python3` in `gcr.io/cloud-builders/docker` (Ubuntu 20.04) is 3.8, so the call always raises.

This is a regression introduced by `065bc4c`, which was an attempted fix for v0.2.1's `jq` failure on 2026-03-09. The original failure was real; the fix was never tested end-to-end (no release tag has been pushed between then and now), so the regression has been latent until now.

## Approach

Rather than upgrade python in the docker step (or rewrite the JSON walk in shell — both tried in earlier revisions of this branch), move the lookup to **cloud build step 0** which already runs `gcr.io/google.com/cloudsdktool/cloud-sdk` — Python 3.13.5. Step 0 writes one line per variant to `/workspace`; the docker steps just `cat` it.

Side benefit: docker steps no longer need any JSON tooling, period — not jq, not python, not curl-against-DockerHub.

## Changes

- **New `scripts/lookup_latest_version.py`** — stdlib-only (`urllib` + `json` + `argparse`). `--latest-tag <T> --suffix <S>` → prints highest semver-shaped tag pointing at the same digest as `<repo>:<T>`, or `0.0.0` on any failure. Repo hardcoded (only ever called for `plainsightai/openfilter-mcp`).
- **`cloudbuild.yaml` step 0** — invokes the script twice, once per variant, before the `SLIM_ONLY` early exit so slim-only builds also get the files.
- **`scripts/docker-build.sh`** — release-tag block reduced to one line: `CURRENT_VERSION=$(cat "/workspace/.latest_version${TAG_SUFFIX}" 2>/dev/null || echo "0.0.0")`. ~22 lines of inline `python3` deleted.

## Verification

| Build | Branch | Substs | Result |
| --- | --- | --- | --- |
| [`296cfe7d-…`](https://console.cloud.google.com/cloud-build/builds;region=us-west1/296cfe7d-5bf2-4c81-a97d-cb8f599c214a?project=934113377363) | `main` | slim, dry-run, v0.2.2 | **FAIL** — `removesuffix` AttributeError |
| [`e4250418-…`](https://console.cloud.google.com/cloud-build/builds;region=us-west1/e4250418-5657-4300-99d7-fab3a234c3b9?project=934113377363) | this branch | same | **SUCCESS** (~5 min) |

## Note on the branch name

`fix/cloudbuild-install-jq` no longer reflects the work — earlier revisions of this branch did install `jq`. Keeping the name to preserve PR continuity; squash-merge drops it from the commit log either way.

## Out of scope

- Real DockerHub push not exercised here (`_DRY_RUN=true`). The fix is in the version-comparison logic, which runs regardless of `DRY_RUN`; the push path was already working in dev-tag builds.
- `_DOCKERHUB_REPO` substitution still threaded into the docker steps even though no trigger overrides it. Unrelated cleanup; track separately if we care.
