### PR TITLE
feat(release): tag-triggered gitops bump for managed MCP (DT-131)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -66,10 +66,19 @@ jobs:
         if: steps.changed.outputs.changed == 'true' && steps.check.outputs.exists == 'false'
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          GH_BOT_USER_PAT: ${{ secrets.GH_BOT_USER_PAT }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "plainsight-bot"
+          git config user.email "cloudinfra@plainsight.ai"
           git tag -a "$TAG" -m "Release $TAG"
-          if ! git push origin "$TAG" 2>&1; then
+          # Push via the bot PAT, not GITHUB_TOKEN. GitHub Actions does
+          # not trigger downstream workflows for events authored by
+          # GITHUB_TOKEN (recursion guard); a PAT-pushed tag does fire
+          # `on: push: tags`, which `release-tag-bump-gitops.yaml`
+          # depends on. http.extraheader= clears any prior auth header
+          # set by actions/checkout above.
+          if ! git -c "http.https://github.com/.extraheader=" \
+               push "https://x-access-token:${GH_BOT_USER_PAT}@github.com/${{ github.repository }}.git" \
+               "$TAG" 2>&1; then
             echo "::warning::Failed to push tag $TAG — may have been created by a concurrent run"
           fi

--- a/.github/workflows/release-tag-bump-gitops.yaml
+++ b/.github/workflows/release-tag-bump-gitops.yaml
@@ -31,10 +31,15 @@ on:
         type: boolean
         default: false
 
-# One bump in flight per ref. Newer tag wins; superseded shards die fast
-# rather than racing to push competing branches into gitops.
+# Serialize the whole pipeline (key is ref-independent on purpose). With
+# `${{ github.ref }}` in the key, two tags fired close together would land
+# in distinct groups and race — if v1.2.3's slim image takes longer to
+# publish than v1.2.4's, the older job can finish second and
+# `open-mechanical-pr`'s supersede step would close v1.2.4's bump PR as
+# stale. Ref-less group + cancel-in-progress gives the actual "newer tag
+# wins" guarantee: a newer tag arriving mid-poll cancels the older one.
 concurrency:
-  group: release-tag-bump-gitops-${{ github.ref }}
+  group: release-tag-bump-gitops
   cancel-in-progress: true
 
 env:
@@ -112,9 +117,9 @@ jobs:
         run: |
           set -euo pipefail
           # Token in the URL only — avoid mutating ~/.gitconfig with a
-          # persistent credential helper. The override defeats any prior
-          # extraheader that might have been left by an actions/checkout
-          # earlier in the job.
+          # persistent credential helper. The empty extraheader override is
+          # defense-in-depth: it forces this clone to use only the URL-
+          # embedded token, ignoring any global http.extraheader.
           git -c "http.https://github.com/.extraheader=" \
               clone --depth 1 \
               "https://x-access-token:${GH_TOKEN}@github.com/${GITOPS_REPO}.git" \
@@ -145,6 +150,14 @@ jobs:
           set -euo pipefail
           # yq is preinstalled on ubuntu-latest runners (mikefarah/yq v4).
           OLD_TAG=$(yq '.image.tag' "gitops/${GITOPS_BUMP_PATH}")
+          # yq prints the literal "null" for a missing key, which would slip
+          # past the `=` compare below and let the writer silently *create*
+          # `.image.tag` if DT-130 ever moves it (e.g. nested under a slim
+          # override). Fail loudly instead of opening a structurally-wrong PR.
+          if [ -z "$OLD_TAG" ] || [ "$OLD_TAG" = "null" ]; then
+            echo "::error::image.tag missing from gitops/${GITOPS_BUMP_PATH} — refusing to bump (schema regression?)."
+            exit 1
+          fi
           if [ "$OLD_TAG" = "$NEW_TAG" ]; then
             echo "image.tag already at ${NEW_TAG} — no diff. open-mechanical-pr will no-op."
           else

--- a/.github/workflows/release-tag-bump-gitops.yaml
+++ b/.github/workflows/release-tag-bump-gitops.yaml
@@ -1,0 +1,186 @@
+# release-tag-bump-gitops.yaml — On openfilter-mcp release tag, open a
+# mechanical bump PR in PlainsightAI/gitops setting the slim image tag of
+# the managed MCP ArgoCD app to the freshly published release. PR-opening
+# mechanics delegated to PlainsightAI/gh-actions-public/open-mechanical-pr.
+#
+# DT-131: https://plainsight-ai.atlassian.net/browse/DT-131
+# Mirrors the openfilter cascade-on-tag pattern (DT-145).
+
+name: Release tag → gitops bump
+
+# Tag glob is shell-style (not regex) — restricts to release semver so
+# pre-release / dev tags (v1.2.3-rc1, v1.2.3-dev) do not bump gitops. The
+# auto-tag workflow already enforces the same shape upstream; this is a
+# defense-in-depth gate against manual tag pushes outside that flow.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Plan only — verify image and diff but do not open a PR'
+        type: boolean
+        default: false
+      override_tag:
+        description: 'Override the resolved release tag (manual smoke testing, e.g. v1.2.3)'
+        type: string
+        default: ''
+      auto_merge_override:
+        description: 'Force auto-merge enablement on the bump PR (default off — gitops auto-merge is org-disabled)'
+        type: boolean
+        default: false
+
+# One bump in flight per ref. Newer tag wins; superseded shards die fast
+# rather than racing to push competing branches into gitops.
+concurrency:
+  group: release-tag-bump-gitops-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITOPS_REPO: PlainsightAI/gitops
+  GITOPS_BUMP_PATH: applications/openfilter-mcp/overrides/base.yaml
+  IMAGE_REPO: plainsightai/openfilter-mcp
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+      # gitops has allow_auto_merge: false at the repo level today; the
+      # composite action would WARN on every run if we asked for it. Flip
+      # this default to 'true' once the gitops repo flag is enabled.
+      AUTO_MERGE: ${{ github.event_name == 'workflow_dispatch' && inputs.auto_merge_override && 'true' || 'false' }}
+    steps:
+      - name: Resolve release version
+        id: version
+        env:
+          REF_TAG: ${{ github.ref_name }}
+          OVERRIDE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.override_tag || '' }}
+        run: |
+          set -euo pipefail
+          TAG="${OVERRIDE_TAG:-${REF_TAG}}"
+          # workflow_dispatch with override_tag is unconstrained — re-check
+          # the shape so a fat-fingered manual run cannot push a malformed
+          # tag into gitops.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::TAG '$TAG' is not a release semver (vX.Y.Z) — refusing to bump."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          SLIM_TAG="${VERSION}-slim"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "slim_tag=$SLIM_TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $TAG → image tag: $SLIM_TAG"
+
+      - name: Wait for slim image on Docker Hub
+        env:
+          IMAGE_TAG: ${{ steps.version.outputs.slim_tag }}
+        run: |
+          set -euo pipefail
+          # Cloud Build publishes plainsightai/openfilter-mcp:<version>-slim
+          # on the same tag push that triggers this workflow. The gitops
+          # bump PR must not land before the image exists, or ArgoCD will
+          # ImagePullBackOff after sync. Poll Docker Hub's tag endpoint
+          # (200 = exists, 404 = not yet) until the image is visible or
+          # the budget runs out. Cloud Build's slim path is ~10–15 min;
+          # 45 min is comfortable headroom without making a busted build
+          # block the runner indefinitely.
+          DEADLINE=$(( $(date +%s) + 45 * 60 ))
+          while :; do
+            CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+              "https://hub.docker.com/v2/repositories/${IMAGE_REPO}/tags/${IMAGE_TAG}")
+            if [ "$CODE" = '200' ]; then
+              echo "${IMAGE_REPO}:${IMAGE_TAG} is published."
+              break
+            fi
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "::error::Timed out waiting for ${IMAGE_REPO}:${IMAGE_TAG} on Docker Hub. Last status: $CODE."
+              exit 1
+            fi
+            echo "Awaiting ${IMAGE_REPO}:${IMAGE_TAG} (last status: $CODE) — re-poll in 30s."
+            sleep 30
+          done
+
+      - name: Clone gitops
+        env:
+          GH_TOKEN: ${{ secrets.GH_BOT_USER_PAT }}
+        run: |
+          set -euo pipefail
+          # Token in the URL only — avoid mutating ~/.gitconfig with a
+          # persistent credential helper. The override defeats any prior
+          # extraheader that might have been left by an actions/checkout
+          # earlier in the job.
+          git -c "http.https://github.com/.extraheader=" \
+              clone --depth 1 \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITOPS_REPO}.git" \
+              gitops
+
+      - name: Verify bump path exists
+        id: precheck
+        run: |
+          set -euo pipefail
+          # DT-130 has to land on gitops main before this file exists. If
+          # it does not yet, exit cleanly — opening a PR against a missing
+          # path would just fail Helm-lint in gitops CI and create churn.
+          # The first release after DT-130 merges will pick up where this
+          # left off, no manual intervention needed.
+          if [ ! -f "gitops/${GITOPS_BUMP_PATH}" ]; then
+            echo "::warning::gitops/${GITOPS_BUMP_PATH} does not exist yet (DT-130 likely not merged). Skipping bump."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump image tag in gitops base override
+        id: bump
+        if: steps.precheck.outputs.skip != 'true'
+        env:
+          NEW_TAG: ${{ steps.version.outputs.slim_tag }}
+        run: |
+          set -euo pipefail
+          # yq is preinstalled on ubuntu-latest runners (mikefarah/yq v4).
+          OLD_TAG=$(yq '.image.tag' "gitops/${GITOPS_BUMP_PATH}")
+          if [ "$OLD_TAG" = "$NEW_TAG" ]; then
+            echo "image.tag already at ${NEW_TAG} — no diff. open-mechanical-pr will no-op."
+          else
+            yq -i ".image.tag = \"${NEW_TAG}\"" "gitops/${GITOPS_BUMP_PATH}"
+            echo "Bumped ${GITOPS_BUMP_PATH}: ${OLD_TAG} → ${NEW_TAG}"
+          fi
+          echo "old_tag=${OLD_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Show planned diff (dry run)
+        if: steps.precheck.outputs.skip != 'true' && env.DRY_RUN == 'true'
+        run: |
+          echo "::group::dry-run diff"
+          git -C gitops diff
+          echo "::endgroup::"
+
+      - name: Open mechanical PR
+        if: steps.precheck.outputs.skip != 'true' && env.DRY_RUN != 'true'
+        uses: PlainsightAI/gh-actions-public/open-mechanical-pr@main
+        with:
+          repo: ${{ env.GITOPS_REPO }}
+          working_directory: gitops
+          # branch_prefix is the supersede key — must be unique to this
+          # cascade so unrelated bot PRs in gitops are not closed.
+          branch_prefix: bump-openfilter-mcp-
+          commit_message: |
+            chore(openfilter-mcp): bump slim image tag → ${{ steps.version.outputs.slim_tag }}
+
+            DT-131 release automation: openfilter-mcp ${{ steps.version.outputs.tag }}.
+          pr_title: "chore(openfilter-mcp): bump slim image tag → ${{ steps.version.outputs.slim_tag }}"
+          pr_body: |
+            Mechanical bump from openfilter-mcp release [`${{ steps.version.outputs.tag }}`](https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}).
+
+            - `${{ env.GITOPS_BUMP_PATH }}`: `image.tag` `${{ steps.bump.outputs.old_tag }}` → `${{ steps.version.outputs.slim_tag }}`
+
+            Image: `${{ env.IMAGE_REPO }}:${{ steps.version.outputs.slim_tag }}` (verified published on Docker Hub before this PR opened).
+
+            Opened by [`release-tag-bump-gitops`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) — see [DT-131](https://plainsight-ai.atlassian.net/browse/DT-131).
+          gh_token: ${{ secrets.GH_BOT_USER_PAT }}
+          auto_merge: ${{ env.AUTO_MERGE }}


### PR DESCRIPTION
## Summary

- On openfilter-mcp release tag, open a mechanical bump PR in PlainsightAI/gitops setting the slim image tag of the managed MCP ArgoCD app (DT-130) to the freshly published release. Closes the loop from `pyproject.toml` version bump → published image → ArgoCD-synced rollout, end-to-end with no manual steps.
- Mirrors the openfilter cascade-on-tag pattern (DT-145): PR mechanics delegated to PlainsightAI/gh-actions-public/open-mechanical-pr.
- Switches auto-tag to push via GH_BOT_USER_PAT instead of GITHUB_TOKEN so the auto-created tag actually fires downstream workflows.

## Changes

- `.github/workflows/release-tag-bump-gitops.yaml` (new):
  - Triggers on `push: tags: 'v[0-9]+.[0-9]+.[0-9]+'` and `workflow_dispatch` with `dry_run` / `override_tag` / `auto_merge_override` knobs for smoke tests.
  - Resolves `<version>-slim` from the tag, polls Docker Hub for that image (45-min budget), then edits `applications/openfilter-mcp/overrides/base.yaml` in a fresh `gitops` clone via yq and opens a bot PR. The image-existence poll is the guard against ArgoCD ImagePullBackOff between merge and Cloud Build completing.
  - Skips cleanly with a `::warning::` if the bump path does not exist yet (DT-130 has to land on `gitops` main first); the next release tag after DT-130 merges picks up where this left off.
- `.github/workflows/auto-tag.yml`: tag push now uses `GH_BOT_USER_PAT` with `http.extraheader=` to clear any actions/checkout-set Authorization header. Required so the auto-pushed tag fires `on: push: tags` downstream — Actions suppresses workflow runs for `GITHUB_TOKEN`-authored events (recursion guard), which would have made the new bump workflow silently never fire on automated releases.

## Defaults flagged for follow-up

- `auto_merge` defaults to `false` because `PlainsightAI/gitops` has `allow_auto_merge: false` org-side today; the composite action would `WARN` on every run otherwise. Flip to `true` (or use the `auto_merge_override` dispatch input) once gitops enables the flag.
- Slack notify deferred — `SLACK_WEBHOOK_URL` is not granted to this repo. Failures surface via the Actions UI; wire Slack later by requesting the org-level secret.

## Test plan

- [x] `actionlint` clean on both workflow files.
- [x] `yq` edit smoke-tested against the real `applications/openfilter-mcp/overrides/base.yaml` from DT-130's PR branch — `tag: latest-slim` → `tag: 1.2.3-slim`, no other keys touched.
- [x] Idempotency check: workflow short-circuits the yq write when `image.tag` already equals the new value; `open-mechanical-pr`'s precheck no-ops on a clean tree.
- [ ] First real exercise blocked on DT-130 landing in gitops main. Pre-real-tag, run `workflow_dispatch` with `override_tag=v0.2.2 dry_run=true` to verify the resolve → poll → diff path end-to-end.
- [ ] Auto-tag PAT-push verified on the next `pyproject.toml` version bump landing on main (e.g. cut a chore PR with a patch bump and watch the tag event fire `release-tag-bump-gitops`).

[DT-131](https://plainsight-ai.atlassian.net/browse/DT-131)

[DT-131]: https://plainsight-ai.atlassian.net/browse/DT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ