### PR TITLE
fix(build): move latest-version lookup into gar-auth prelude (DT-159)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,10 +31,12 @@ availableSecrets:
       env: 'HF_TOKEN'
 
 steps:
-  # Step 0: Prelude — write the GAR access token so the slim build can start
-  # in parallel with the index step. PR / dev tag builds push to GAR and read
-  # this token in scripts/docker-build.sh; release tag builds skip it and the
-  # file is simply absent.
+  # Step 0: Prelude — write the GAR access token and the DockerHub-latest
+  # version files. Both the index step and the slim step depend on this
+  # output (slim reads /workspace/.latest_version-slim in docker-build.sh),
+  # and slim runs in parallel with index, so the lookup MUST happen here —
+  # not inside the index step — to avoid a read-before-write race that
+  # would make slim treat every release as a downgrade-safe latest bump.
   - id: 'gar-auth'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
@@ -48,6 +50,11 @@ steps:
         else
           echo "Release build: GAR auth not needed"
         fi
+        # Computed up here in cloud-sdk (which has python3) so the docker
+        # steps don't need any JSON tooling. Runs unconditionally — both
+        # release and slim-only tags need these files downstream.
+        python3 scripts/lookup_latest_version.py --latest-tag latest --suffix= > /workspace/.latest_version
+        python3 scripts/lookup_latest_version.py --latest-tag latest-slim --suffix=-slim > /workspace/.latest_version-slim
 
   # Step 1: Upload source, run GPU job, download index
   - id: 'index'
@@ -63,11 +70,6 @@ steps:
         # Auto-detect slim-only from tag name (e.g. v1.0.0-slim-dev)
         SLIM_ONLY="${_SLIM_ONLY}"
         if [[ "${TAG_NAME}" == *slim* ]]; then SLIM_ONLY=true; fi
-        # Compute the DockerHub :latest{,-slim} version up here in cloud-sdk
-        # (which has python3) so the docker steps don't need any JSON tooling.
-        # Runs before the SLIM_ONLY exit so slim-only builds also get the file.
-        python3 scripts/lookup_latest_version.py --latest-tag latest --suffix= > /workspace/.latest_version
-        python3 scripts/lookup_latest_version.py --latest-tag latest-slim --suffix=-slim > /workspace/.latest_version-slim
         if [[ "$$SLIM_ONLY" == "true" ]]; then echo "SLIM_ONLY: skipping index build"; exit 0; fi
         tar czf /tmp/src.tar.gz --exclude='.git' --exclude='indexes' .
         gsutil cp /tmp/src.tar.gz gs://${_GCS_BUCKET}/builds/${BUILD_ID}/src.tar.gz

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,7 +37,7 @@ steps:
   # and slim runs in parallel with index, so the lookup MUST happen here —
   # not inside the index step — to avoid a read-before-write race that
   # would make slim treat every release as a downgrade-safe latest bump.
-  - id: 'gar-auth'
+  - id: 'prelude'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
@@ -58,7 +58,7 @@ steps:
 
   # Step 1: Upload source, run GPU job, download index
   - id: 'index'
-    waitFor: ['gar-auth']
+    waitFor: ['prelude']
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     allowFailure: true  # full-pipeline failures must not block the slim push
     entrypoint: 'bash'
@@ -137,11 +137,11 @@ steps:
         bash scripts/docker-build.sh --dockerfile Dockerfile.gpu --tag-suffix "" --latest-tag "latest" --platform linux/amd64
 
   # Step 3: Slim Docker build (no code-context, no indexes, no ML deps).
-  # Runs in parallel with the index/full pipeline — only depends on gar-auth
-  # for PR/dev token, and the slim DockerHub-latest lookup is self-contained
-  # in docker-build.sh (no shared workspace state with the full build).
+  # Runs in parallel with the index/full pipeline — depends on prelude
+  # for both the PR/dev token and the DockerHub-latest version files
+  # (written by the prelude so this step doesn't race the index step).
   - id: 'slim-build'
-    waitFor: ['gar-auth']
+    waitFor: ['prelude']
     name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     secretEnv: ['DOCKERHUB_USERNAME', 'DOCKERHUB_TOKEN']


### PR DESCRIPTION
## Summary

Follow-up to #56. The parallelized slim step (`waitFor: ['gar-auth']`) reads `/workspace/.latest_version-slim` via `docker-build.sh`, but #53 had moved the `lookup_latest_version.py` calls into the index step — which the slim step now runs in parallel with. Slim raced the write, fell back to `0.0.0`, and would have updated `:latest-slim` on every release including rollbacks.

This is the race [@lucasmundim flagged on #56](https://github.com/PlainsightAI/openfilter-mcp/pull/56#pullrequestreview-2103860006); I missed it because my branch base predated #53.

## Changes

- `cloudbuild.yaml`: move both `lookup_latest_version.py` calls from the `index` step into the `gar-auth` prelude. Both `index` and `slim-build` now waitFor `gar-auth`, so the lookup files are guaranteed present before either reads them. Net move: two lines from step 1 → step 0, plus comment updates documenting the invariant.

No behavior change for release builds beyond closing the race — the lookups still run unconditionally and produce the same files at the same paths.

## Test plan

- [ ] Cloud Build graph: `gar-auth` writes both `.latest_version` files before `slim-build` starts.
- [ ] Push a clean release tag → both full and slim images publish with correct semver-vs-latest comparison.
- [ ] Push a rollback tag (lower semver than current `:latest-slim`) → slim does NOT clobber `:latest-slim` (i.e. lookup correctly found the higher current version).

[DT-159](https://plainsight-ai.atlassian.net/browse/DT-159)

[DT-159]: https://plainsight-ai.atlassian.net/browse/DT-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ