### PR TITLE
feat(ci): enforce changelog updates and dismiss stale approvals on drive-by pushes [DT-163]

### DIFF
--- a/.github/workflows/check-release-log.yaml
+++ b/.github/workflows/check-release-log.yaml
@@ -22,7 +22,6 @@ permissions:
 
 jobs:
   check-release-log:
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -34,11 +33,13 @@ jobs:
         uses: PlainsightAI/gh-actions-public/check-release-log@main
         with:
           # Exclusion list, not allowlist — see header comment for rationale.
-          # `deployment/**` and `.github/environments/**` are auto-bumped by
-          # the deploy workflow committing image.tag back to main; those
-          # commits don't go through PRs, but excluding the paths keeps the
-          # gate honest if a human ever edits them directly. `docs/**`,
-          # `tests/**`, `.github/**`, and `**/*.md` are non-shipping.
+          # `deployment/**` and `.github/**` (which covers the auto-bumped
+          # `.github/environments/**`) are touched by the deploy workflow
+          # committing image.tag back to main; those commits don't go through
+          # PRs, but excluding the paths keeps the gate honest if a human ever
+          # edits them directly. `docs/**`, `tests/**`, and `**/*.md` are
+          # non-shipping — note this means pure-test PRs won't require a
+          # changelog entry; add one manually for notable QA improvements.
           ignore-paths: |
             .github/**
             deployment/**

--- a/.github/workflows/check-release-log.yaml
+++ b/.github/workflows/check-release-log.yaml
@@ -1,0 +1,47 @@
+# PR backstop: any substantive change to this repo (package source, build
+# infra, runtime config) must come with a RELEASE.md entry. `ignore-paths`
+# scopes the gate by *exclusion* — anything not listed below counts as
+# substantive, so a new top-level source dir gets caught by default instead
+# of silently slipping through an outdated `source-paths` allowlist.
+#
+# The composite also validates RELEASE.md format via changelog-parser-action
+# and (when a VERSION file is present) checks version consistency + that
+# VERSION is not behind base. This repo carries its version in pyproject.toml
+# rather than a VERSION file, so those two sub-checks no-op gracefully.
+#
+# Dependabot PRs are skipped inside the action.
+name: Check Release Log
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-release-log:
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run release log check
+        uses: PlainsightAI/gh-actions-public/check-release-log@main
+        with:
+          # Exclusion list, not allowlist — see header comment for rationale.
+          # `deployment/**` and `.github/environments/**` are auto-bumped by
+          # the deploy workflow committing image.tag back to main; those
+          # commits don't go through PRs, but excluding the paths keeps the
+          # gate honest if a human ever edits them directly. `docs/**`,
+          # `tests/**`, `.github/**`, and `**/*.md` are non-shipping.
+          ignore-paths: |
+            .github/**
+            deployment/**
+            docs/**
+            tests/**
+            **/*.md

--- a/.github/workflows/external-review-freshness.yaml
+++ b/.github/workflows/external-review-freshness.yaml
@@ -1,0 +1,41 @@
+name: External review freshness
+
+# Dismiss APPROVED reviews when a PR authored by an untrusted contributor
+# receives new commits. Trust is keyed on the PR *author*'s repo collaborator
+# permission (admin/maintain/write → trusted; everyone else → dismiss every
+# approval on the PR, including approvals granted by maintainers). Forces
+# re-review of any new code from someone the repo doesn't already trust.
+#
+# Complements (does not replace) GitHub's native
+# `dismiss_stale_reviews_on_push` rule. The native rule dismisses approvals
+# on *every* push, including a maintainer's own fixup to their own PR; this
+# action only fires when the PR author is untrusted, so trusted-maintainer
+# self-pushes don't invalidate fresh approvals.
+#
+# Must run on pull_request_target (not pull_request) so the job has
+# base-repo permissions to dismiss reviews on fork PRs.
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+# Per-PR concurrency: a force-push or rapid fixup-push fires `synchronize`
+# twice in quick succession, queuing two dismissal runs against the same
+# review set. Cancel the older run so only the latest push's freshness check
+# survives — avoids racy double-dismiss attempts.
+concurrency:
+  group: external-review-freshness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dismiss:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: PlainsightAI/gh-actions-public/external-review-freshness@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dry-run: "false"

--- a/.github/workflows/external-review-freshness.yaml
+++ b/.github/workflows/external-review-freshness.yaml
@@ -14,6 +14,11 @@ name: External review freshness
 #
 # Must run on pull_request_target (not pull_request) so the job has
 # base-repo permissions to dismiss reviews on fork PRs.
+#
+# DO NOT add `actions/checkout` (or any step that materializes PR head code)
+# to this workflow. `pull_request_target` runs with write-scoped base-repo
+# secrets; checking out untrusted fork code under that context is the classic
+# pwn vector. This workflow only needs PR metadata via the GitHub API.
 
 on:
   pull_request_target:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+# Changelog
+
+openfilter-mcp release notes. Format follows
+[Keep a Changelog](https://keepachangelog.com); newest at the top.
+
+New PRs should add bullets under `## [Unreleased]`. When cutting a release,
+rename the `[Unreleased]` heading to the new `## vX.Y.Z` and bump
+`pyproject.toml` in the same PR (the `auto-tag` workflow keys off
+`pyproject.toml` changes on main to push the tag).
+
+## [Unreleased]
+
+### Added
+
+- `check-release-log` gate on every PR to `main` (enforces this changelog is
+  updated for substantive changes; scoped via `ignore-paths` so docs / tests
+  / CI / deploy-config-only PRs are no-ops).
+- `external-review-freshness` workflow: dismisses approvals on PRs authored
+  by untrusted contributors whenever they push new commits, so any new code
+  from a non-collaborator forces re-review.
+
+## v0.2.2
+
+- Initial tracked release. Prior history is captured in git only.


### PR DESCRIPTION
Adopts two composite actions from PlainsightAI/gh-actions-public:

- check-release-log: PR backstop that requires RELEASE.md to be updated for substantive changes. Scoped with ignore-paths so docs / tests / CI / deploy-config-only PRs no-op. VERSION-file sub-checks skip gracefully — this repo's version lives in pyproject.toml.

- external-review-freshness: runs on pull_request_target.synchronize and dismisses every APPROVED review on a PR whose author lacks admin/maintain/write on the repo. Forces re-review of any new code from a non-collaborator. Per-PR concurrency cancels stale runs on rapid fixup-push, mirroring openfilter's production config.

Bootstraps RELEASE.md at v0.2.2 with an [Unreleased] section so the parser has a current entry and contributors have an obvious place to add bullets.