### PR TITLE
fix(deploy): scale down to 1 replica to support stateful session-token elicitation

### DIFF
--- a/deployment/openfilter-mcp/overrides/production.yaml
+++ b/deployment/openfilter-mcp/overrides/production.yaml
@@ -5,7 +5,7 @@
 image:
   repository: us-west1-docker.pkg.dev/plainsightai-prod/oci/openfilter-mcp
   tag: "74f4878ab3da9add6c87c7ef255739d28108152e" # {"$imagepolicy": "production:openfilter-mcp:tag"}
-replicaCount: 2
+replicaCount: 1
 plainsightApiUrl: "https://api.prod.plainsight.tech"
 oauth:
   asUrl: "https://api.prod.plainsight.tech"


### PR DESCRIPTION
## Summary
- Scale down openfilter-mcp replicas from 2 to 1 in production.

## Changes
- `deployment/openfilter-mcp/overrides/production.yaml`: Set `replicaCount: 1`.

## Test plan
- Verified that Streamable HTTP session ID mappings and FastMCP's OAuth elicitation token cache are stored in memory and require stateful session consistency.
- Lowered replica count to 1 to resolve connection mismatch ("Session not found") when load balancing across multiple pods.