### PR TITLE
chore(deploy): drop git-push deploy step from Deployments workflow (DT-166)

### DIFF
--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -17,17 +17,26 @@ permissions:
 
 concurrency:
   group: deployments
-  cancel-in-progress: true   # build-only now (no deploy step); a build superseded by a newer SHA is safe to drop
+  # Build-only now, but do NOT cancel superseded builds: ArgoCD Image Updater
+  # selects the newest GAR image tagged with a commit SHA, so every merged SHA
+  # must have its image built. Dropping an intermediate build would leave that
+  # SHA with no image — invisible to Image Updater and unavailable for a
+  # rollback/pin to a non-HEAD SHA.
+  cancel-in-progress: false
 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
-    # ArgoCD Image Updater writes image bumps into the gitops repo, not into
-    # deployment/** here; env-config changes are applied by
-    # apply-environments.yaml. Ignoring both still avoids a build retrigger on
-    # any manual edits to these paths.
+    # Ignore chart/env edits here on purpose. This workflow builds only the
+    # app image (Dockerfile.slim) → GAR; it does not render or ship the chart.
+    # ArgoCD sources the chart live from this repo's deployment/openfilter-mcp
+    # at targetRevision HEAD (selfHeal), so a templates/values/Chart.yaml edit
+    # auto-deploys on merge WITHOUT a build. Triggering a build on a chart-only
+    # change would only produce a new-SHA image with identical code, which
+    # Image Updater (newest-build) would then redeploy — pure churn, not a
+    # delta deploy. .github/environments/** is applied by apply-environments.yaml.
     paths-ignore:
       - 'deployment/**'
       - '.github/environments/**'

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -1,10 +1,11 @@
 # deployments.yaml — Continuous build for the managed slim
 # openfilter-mcp. On every merge to main, build the slim image
 # (Dockerfile.slim) to GAR tagged with the commit SHA. Rollout is no
-# longer driven from here: ArgoCD Image Updater (configured on the
-# openfilter-mcp ApplicationSet in PlainsightAI/gitops) watches GAR for
-# new SHA tags and writes the bump back into the gitops repo itself, so
-# this workflow no longer needs `contents: write` or a deploy step.
+# longer driven from here: our managed environments deploy the public Docker
+# Hub slim releases, tracked by ArgoCD Image Updater (configured on the
+# openfilter-mcp ApplicationSet in PlainsightAI/gitops). This workflow no
+# longer needs `contents: write` or a deploy step, and is retained simply
+# to continuously exercise the GAR build path on merge.
 #
 # The tag-triggered Cloud Build → Docker Hub release (auto-tag.yml +
 # cloudbuild.yaml) still publishes the public full/slim image artifacts
@@ -17,12 +18,10 @@ permissions:
 
 concurrency:
   group: deployments
-  # Build-only now, but do NOT cancel superseded builds: ArgoCD Image Updater
-  # selects the newest GAR image tagged with a commit SHA, so every merged SHA
-  # must have its image built. Dropping an intermediate build would leave that
-  # SHA with no image — invisible to Image Updater and unavailable for a
-  # rollback/pin to a non-HEAD SHA.
-  cancel-in-progress: false
+  # Safe to cancel superseded builds — this workflow pushes GAR images as
+  # continuous validation, but actual rollouts track the tag-triggered
+  # Docker Hub slim releases via Image Updater.
+  cancel-in-progress: true
 
 on:
   workflow_dispatch:
@@ -59,8 +58,7 @@ jobs:
         uses: PlainsightAI/gh-actions-public/publish-docker-image@main
         env:
           # Consumed by `make build-image` / `publish-image` / `image-tag`
-          # as the image tag — the SHA tag ArgoCD Image Updater detects in
-          # GAR and writes into the gitops repo.
+          # as the image tag for the GAR build.
           VERSION: ${{ github.sha }}
         with:
           environment: production

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -1,22 +1,20 @@
-# deployments.yaml — Continuous deployment for the managed slim
+# deployments.yaml — Continuous build for the managed slim
 # openfilter-mcp. On every merge to main, build the slim image
-# (Dockerfile.slim) to GAR tagged with the commit SHA, then roll it
-# through development → staging → production via the shared
-# deploy-service reusable workflow. Each env step rewrites image.tag in
-# deployment/openfilter-mcp/overrides/<env>.yaml and commits it back;
-# ArgoCD (the openfilter-mcp ApplicationSet in PlainsightAI/gitops)
-# syncs from there.
+# (Dockerfile.slim) to GAR tagged with the commit SHA. Rollout is no
+# longer driven from here: ArgoCD Image Updater (configured on the
+# openfilter-mcp ApplicationSet in PlainsightAI/gitops) watches GAR for
+# new SHA tags and writes the bump back into the gitops repo itself, so
+# this workflow no longer needs `contents: write` or a deploy step.
 #
-# This is the managed-deployment path only. The tag-triggered Cloud
-# Build → Docker Hub release (auto-tag.yml + cloudbuild.yaml) still
-# publishes the public full/slim image artifacts and is unaffected.
+# The tag-triggered Cloud Build → Docker Hub release (auto-tag.yml +
+# cloudbuild.yaml) still publishes the public full/slim image artifacts
+# and is unaffected.
 #
-# Mirrors plainsight-api's Deployments workflow and
-# openfilter-pipelines-controller#53.
+# Mirrors plainsight-api's Deployments workflow.
 name: Deployments
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 concurrency:
@@ -57,15 +55,6 @@ jobs:
           VERSION: ${{ github.sha }}
         with:
           environment: production
-
-  deploy:
-    needs: build
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    uses: PlainsightAI/gh-actions-public/.github/workflows/deploy-service.yaml@main
-    with:
-      service-name: openfilter-mcp
-      manifests-path: deployment
-    secrets: inherit
 
   # Build a PR-tagged image when a PR carries the `preview` label, so a
   # preview ApplicationSet in gitops can pull it. No-op until that

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -19,16 +19,17 @@ permissions:
 
 concurrency:
   group: deployments
-  cancel-in-progress: false   # serialize, don't drop a queued deploy
+  cancel-in-progress: true   # build-only now (no deploy step); a build superseded by a newer SHA is safe to drop
 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
-    # The deploy step commits image.tag bumps back into deployment/**;
-    # env-config changes are applied by apply-environments.yaml. Ignoring
-    # both here stops those commits retriggering a build + redeploy.
+    # ArgoCD Image Updater writes image bumps into the gitops repo, not into
+    # deployment/** here; env-config changes are applied by
+    # apply-environments.yaml. Ignoring both still avoids a build retrigger on
+    # any manual edits to these paths.
     paths-ignore:
       - 'deployment/**'
       - '.github/environments/**'
@@ -51,7 +52,8 @@ jobs:
         uses: PlainsightAI/gh-actions-public/publish-docker-image@main
         env:
           # Consumed by `make build-image` / `publish-image` / `image-tag`
-          # as the image tag — the same SHA the deploy step pins.
+          # as the image tag — the SHA tag ArgoCD Image Updater detects in
+          # GAR and writes into the gitops repo.
           VERSION: ${{ github.sha }}
         with:
           environment: production

--- a/.github/workflows/deployments.yaml
+++ b/.github/workflows/deployments.yaml
@@ -9,8 +9,6 @@
 # The tag-triggered Cloud Build → Docker Hub release (auto-tag.yml +
 # cloudbuild.yaml) still publishes the public full/slim image artifacts
 # and is unaffected.
-#
-# Mirrors plainsight-api's Deployments workflow.
 name: Deployments
 
 permissions:

--- a/deployment/openfilter-mcp/Chart.yaml
+++ b/deployment/openfilter-mcp/Chart.yaml
@@ -3,9 +3,8 @@ name: openfilter-mcp
 description: Managed slim openfilter-mcp deployment (platform tools only — no code-search, no PVC, no GPU)
 type: application
 version: 0.1.0
-# image.tag is the source of truth and is bumped per-environment by the
-# Deployments workflow (.github/workflows/deployments.yaml) via the Flux
-# $imagepolicy annotations in overrides/<env>.yaml; appVersion is pinned
-# so it doesn't lag behind and ship a misleading
-# app.kubernetes.io/version label.
+# For the managed deployment, image.tag is the source of truth and is bumped
+# per-environment by gitops's ArgoCD Image Updater, which writes
+# applications/openfilter-mcp/image-tag.yaml; appVersion is pinned so it
+# doesn't lag behind and ship a misleading app.kubernetes.io/version label.
 appVersion: "0.0.0"

--- a/deployment/openfilter-mcp/overrides/development.yaml
+++ b/deployment/openfilter-mcp/overrides/development.yaml
@@ -1,10 +1,5 @@
-# image.tag is rewritten in place on every merge to main by the
-# Deployments workflow's image-policy-applier step — the trailing
-# $imagepolicy annotation is the marker it keys off. Keep it quoted:
-# an all-digit placeholder would otherwise parse as the integer 0.
-image:
-  repository: us-west1-docker.pkg.dev/plainsightai-prod/oci/openfilter-mcp
-  tag: "92f78c9e0a5157b23a2eb66eb1f0c965ca6ef6ea" # {"$imagepolicy": "development:openfilter-mcp:tag"}
+# image.repository/tag come from gitops ArgoCD Image Updater
+# (applications/openfilter-mcp/image-tag.yaml), not this file.
 replicaCount: 1
 plainsightApiUrl: "https://api.dev.plainsight.tech"
 oauth:

--- a/deployment/openfilter-mcp/overrides/production.yaml
+++ b/deployment/openfilter-mcp/overrides/production.yaml
@@ -1,10 +1,5 @@
-# image.tag is rewritten in place on every merge to main by the
-# Deployments workflow's image-policy-applier step — the trailing
-# $imagepolicy annotation is the marker it keys off. Keep it quoted:
-# an all-digit placeholder would otherwise parse as the integer 0.
-image:
-  repository: us-west1-docker.pkg.dev/plainsightai-prod/oci/openfilter-mcp
-  tag: "92f78c9e0a5157b23a2eb66eb1f0c965ca6ef6ea" # {"$imagepolicy": "production:openfilter-mcp:tag"}
+# image.repository/tag come from gitops ArgoCD Image Updater
+# (applications/openfilter-mcp/image-tag.yaml), not this file.
 replicaCount: 1
 plainsightApiUrl: "https://api.prod.plainsight.tech"
 oauth:

--- a/deployment/openfilter-mcp/overrides/staging.yaml
+++ b/deployment/openfilter-mcp/overrides/staging.yaml
@@ -1,10 +1,5 @@
-# image.tag is rewritten in place on every merge to main by the
-# Deployments workflow's image-policy-applier step — the trailing
-# $imagepolicy annotation is the marker it keys off. Keep it quoted:
-# an all-digit placeholder would otherwise parse as the integer 0.
-image:
-  repository: us-west1-docker.pkg.dev/plainsightai-prod/oci/openfilter-mcp
-  tag: "92f78c9e0a5157b23a2eb66eb1f0c965ca6ef6ea" # {"$imagepolicy": "staging:openfilter-mcp:tag"}
+# image.repository/tag come from gitops ArgoCD Image Updater
+# (applications/openfilter-mcp/image-tag.yaml), not this file.
 replicaCount: 1
 plainsightApiUrl: "https://api.staging.plainsight.tech"
 oauth:

--- a/deployment/openfilter-mcp/values.yaml
+++ b/deployment/openfilter-mcp/values.yaml
@@ -8,13 +8,12 @@ fullnameOverride: ""
 
 image:
   # Default repository is the public Docker Hub repository.
-  # For our managed environments, this is overridden to Google Artifact Registry (GAR) in the overrides files.
+  # For our managed environments, ArgoCD Image Updater writes overrides directly to
+  # applications/openfilter-mcp/image-tag.yaml in the gitops repo.
   repository: plainsightai/openfilter-mcp
-  # tag is owned per-environment by overrides/<env>.yaml and bumped on
-  # every merge to main by the Deployments workflow's image-policy-applier
-  # step (keyed off the Flux $imagepolicy annotation there). The default
-  # below is an inert placeholder — Argo always layers an override on top.
-  # SHA tags are immutable, so IfNotPresent is safe.
+  # tag is owned by ArgoCD Image Updater (tracking the Docker Hub slim releases).
+  # The default below is an inert placeholder — Argo always layers the updater's
+  # write-back on top. SHA tags are immutable, so IfNotPresent is safe.
   tag: "0000000000000000000000000000000000000000"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Rollout of the managed slim openfilter-mcp is now driven by ArgoCD Image Updater, configured on the openfilter-mcp ApplicationSet in PlainsightAI/gitops. The updater watches GAR for new commit-SHA tags and writes the bump back into the gitops repo's
applications/openfilter-mcp/image-tag.yaml, so this workflow no longer needs to commit image.tag bumps into deployment/<service>/overrides on this repo's main.

Remove the `deploy` job (deploy-service.yaml reusable workflow) and drop `contents: write` down to `contents: read`. The `build` job still publishes the commit-SHA image to GAR — which is the artifact the updater pulls — and the `preview` job is unchanged.

Mirrors plainsight-api's equivalent Deployments refactor (DT-164).