### PR TITLE
feat(deploy): publish openfilter-mcp Helm chart to Docker Hub OCI (DT-166)

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -4,33 +4,60 @@ on:
   push:
     tags: ["v*.*.*"]
 
+# Serialize per-tag so a re-run (or delete+repush) can't race a prior publish.
+# cancel-in-progress: false — never abort an in-flight push to the public registry.
+concurrency:
+  group: publish-chart-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   DOCKERHUB_USERNAME: plainsightai
 
 jobs:
   publish-chart:
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
 
+      # The tag glob (v*.*.*) is laxer than semver: it matches v1.2.3-rc1,
+      # v1.2.3+build.4, vDEV.test.x, four-part v0.1.0.1, and shell-metachar
+      # tags. Validate strictly before the version is ever interpolated, and
+      # publish stable releases only (no pre-release / build metadata).
       - id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          ref="$GITHUB_REF_NAME"
+          if [[ ! "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$ref' is not a stable semver tag (vMAJOR.MINOR.PATCH); refusing to publish." >&2
+            exit 1
+          fi
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
 
       - uses: azure/setup-helm@v5
 
+      - name: Lint and render chart
+        run: |
+          helm lint deployment/openfilter-mcp
+          helm template deployment/openfilter-mcp >/dev/null
+
       - name: Log in to DockerHub (Helm OCI)
-        run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | helm registry login registry-1.docker.io -u ${{ env.DOCKERHUB_USERNAME }} --password-stdin
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: echo "$DOCKERHUB_TOKEN" | helm registry login registry-1.docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Package Helm chart
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           helm package deployment/openfilter-mcp \
-            --version ${{ steps.version.outputs.version }} \
-            --app-version ${{ steps.version.outputs.version }}
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination .
 
       - name: Push Helm chart to DockerHub OCI
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          helm push openfilter-mcp-${{ steps.version.outputs.version }}.tgz \
+          helm push "openfilter-mcp-${VERSION}.tgz" \
             oci://registry-1.docker.io/plainsightai

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,36 @@
+name: Publish Helm chart to Docker Hub OCI
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+env:
+  DOCKERHUB_USERNAME: plainsightai
+
+jobs:
+  publish-chart:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/setup-helm@v5
+
+      - name: Log in to DockerHub (Helm OCI)
+        run: echo "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}" | helm registry login registry-1.docker.io -u ${{ env.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Package Helm chart
+        run: |
+          helm package deployment/openfilter-mcp \
+            --version ${{ steps.version.outputs.version }} \
+            --app-version ${{ steps.version.outputs.version }}
+
+      - name: Push Helm chart to DockerHub OCI
+        run: |
+          helm push openfilter-mcp-${{ steps.version.outputs.version }}.tgz \
+            oci://registry-1.docker.io/plainsightai

--- a/deployment/openfilter-mcp/Chart.yaml
+++ b/deployment/openfilter-mcp/Chart.yaml
@@ -7,4 +7,7 @@ version: 0.1.0
 # per-environment by gitops's ArgoCD Image Updater, which writes
 # applications/openfilter-mcp/image-tag.yaml; appVersion is pinned so it
 # doesn't lag behind and ship a misleading app.kubernetes.io/version label.
+# This chart is also published to oci://registry-1.docker.io/plainsightai on
+# every v*.*.* tag (.github/workflows/publish-chart.yaml) so external users can
+# `helm install`; at package time --version/--app-version are set from the tag.
 appVersion: "0.0.0"


### PR DESCRIPTION
## Summary
- Add a CI workflow that packages the openfilter-mcp Helm chart and `helm push`es it to `oci://registry-1.docker.io/plainsightai` on every `v*.*.*` tag, version-pinned from the tag.
- Gives external users a public `helm install` path; previously only the image published to Docker Hub, the chart had no public distribution.
- Refresh the stale Chart.yaml comment to reflect the gitops ArgoCD Image Updater bump source and the new OCI publish path.

## Changes
- `.github/workflows/publish-chart.yaml`: new standalone workflow (`publish-chart` job) — checkout, setup-helm, registry login, `helm package`, `helm push`. `--version`/`--app-version` derived from `${GITHUB_REF_NAME#v}`. No chart dependencies, so no `helm dependency update` step.
- `deployment/openfilter-mcp/Chart.yaml`: reword the image.tag/appVersion comment.

## Test plan
- [x] `helm lint deployment/openfilter-mcp` passes (0 charts failed).
- [x] `helm package deployment/openfilter-mcp --version 0.1.0 --app-version 0.1.0` succeeds locally.
- [x] Workflow YAML parses.
- [ ] Verify `DOCKERHUB_ACCESS_TOKEN` secret exists in the openfilter-mcp repo (could not list secrets; opfc has it).

[DT-166](https://plainsight-ai.atlassian.net/browse/DT-166)

[DT-166]: https://plainsight-ai.atlassian.net/browse/DT-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ